### PR TITLE
Add clang-tidy config.

### DIFF
--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -103,6 +103,14 @@ CheckOptions:
   readability-identifier-naming.PublicMethodCase: "lower_case"
   readability-identifier-naming.VirtualMethodCase: "lower_case"
 
+  # Parameter naming rules
+  readability-identifier-naming.ParameterCase: "lower_case"
+  readability-identifier-naming.ParameterPackCase: "lower_case"
+  readability-identifier-naming.PointerParameterCase: "lower_case"
+  readability-identifier-naming.TemplateParameterCase: "lower_case"
+  readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
+  readability-identifier-naming.ValueTemplateParameterCase: "lower_case"
+
   # Variable naming rules
   readability-identifier-naming.GlobalPointerCase: "lower_case"
   readability-identifier-naming.GlobalVariableCase: "lower_case"
@@ -124,11 +132,3 @@ CheckOptions:
   readability-identifier-naming.ProtectedMemberPrefix: "m_"
   readability-identifier-naming.PublicMemberCase: "lower_case"
   readability-identifier-naming.PublicMemberPrefix: ""
-
-  # Parameter naming rules
-  readability-identifier-naming.ParameterCase: "lower_case"
-  readability-identifier-naming.ParameterPackCase: "lower_case"
-  readability-identifier-naming.PointerParameterCase: "lower_case"
-  readability-identifier-naming.TemplateParameterCase: "lower_case"
-  readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
-  readability-identifier-naming.ValueTemplateParameterCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -2,7 +2,8 @@
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
 # - `readability-identifier-length` because it's case-dependent.
 # - `readability-named-parameter` because we don't want to enforce that all parameters have a name.
-# - `readability-simplify-boolean-expr` because changing `false == x` to `!x` violates our style guide.
+# - `readability-simplify-boolean-expr` because changing `false == x` to `!x` violates our style
+#   guide.
 Checks: >-
   bugprone-*,
   -bugprone-easily-swappable-parameters,
@@ -23,13 +24,15 @@ Checks: >-
 WarningsAsErrors: "*"
 FormatStyle: "file"
 CheckOptions:
-  # This is necessary to allow simple classes (with all members being public) that have a constructor
+  # This is necessary to allow simple classes (with all members being public) that have a
+  # constructor
   misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
 
-  # NOTE: In the naming rules below, a rule may imply another (e.g., `ClassCase` seems to imply `AbstractClassCase`),
-  # so ideally we could only specify the parent rule if we didn't need to customize the child rules. However, these
-  # relationships are not documented, so we can't rely on them. Instead, we explicitly specify all rules (except those
-  # that should have reasonable defaults like `""` for `ClassPrefix`).
+  # NOTE: In the naming rules below, a rule may imply another (e.g., `ClassCase` seems to imply
+  # `AbstractClassCase`), so ideally we'd only specify the parent rule if we didn't need to
+  # customize the child rules. However, these relationships aren't documented, so we can't rely on
+  # them. Instead, we explicitly specify all rules (except those that should have reasonable
+  # defaults, e.g., `""` for `ClassPrefix`).
 
   # Macro naming rules
   readability-identifier-naming.MacroDefinitionCase: "UPPER_CASE"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -1,3 +1,6 @@
+FormatStyle: "file"
+WarningsAsErrors: "*"
+
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
 # - `readability-identifier-length` because it's case-dependent.
@@ -21,8 +24,6 @@ Checks: >-
   -readability-named-parameter,
   -readability-simplify-boolean-expr,
 
-WarningsAsErrors: "*"
-FormatStyle: "file"
 CheckOptions:
   # This is necessary to allow simple classes (with all members being public) that have a
   # constructor

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -1,0 +1,130 @@
+# Disabled checks:
+# - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
+# - `readability-identifier-length` because it's case-dependent.
+# - `readability-named-parameter` because we don't want to enforce that all parameters have a name.
+# - `readability-simplify-boolean-expr` because changing `false == x` to `!x` violates our style guide.
+Checks: >-
+  bugprone-*,
+  -bugprone-easily-swappable-parameters,
+  cert-*,
+  clang-analyzer-*,
+  clang-diagnostic-*,
+  concurrency-*,
+  cppcoreguidelines-*,
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -readability-identifier-length,
+  -readability-named-parameter,
+  -readability-simplify-boolean-expr,
+
+WarningsAsErrors: "*"
+FormatStyle: "file"
+CheckOptions:
+  # This is necessary to allow simple classes (with all members being public) that have a constructor
+  misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
+
+  # NOTE: In the naming rules below, a rule may imply another (e.g., `ClassCase` seems to imply `AbstractClassCase`),
+  # so ideally we could only specify the parent rule if we didn't need to customize the child rules. However, these
+  # relationships are not documented, so we can't rely on them. Instead, we explicitly specify all rules (except those
+  # that should have reasonable defaults like `""` for `ClassPrefix`).
+
+  # Macro naming rules
+  readability-identifier-naming.MacroDefinitionCase: "UPPER_CASE"
+
+  # Namespace naming rules
+  readability-identifier-naming.NamespaceCase: "lower_case"
+  readability-identifier-naming.InlineNamespaceCase: "lower_case"
+
+  # Class naming rules
+  readability-identifier-naming.AbstractClassCase: "CamelCase"
+  readability-identifier-naming.ClassCase: "CamelCase"
+  readability-identifier-naming.StructCase: "CamelCase"
+
+  # Union naming rules
+  readability-identifier-naming.UnionCase: "CamelCase"
+
+  # Constexpr naming rules
+  readability-identifier-naming.ConstexprVariableCase: "CamelCase"
+  readability-identifier-naming.ConstexprVariablePrefix: "c"
+
+  # Constant naming rules
+  readability-identifier-naming.ClassConstantCase: "CamelCase"
+  readability-identifier-naming.ClassConstantPrefix: "c"
+  readability-identifier-naming.ConstantCase: "CamelCase"
+  readability-identifier-naming.ConstantPrefix: "c"
+  readability-identifier-naming.GlobalConstantCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantPrefix: "c"
+  readability-identifier-naming.GlobalConstantPointerCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantPointerPrefix: "c"
+  readability-identifier-naming.StaticConstantCase: "CamelCase"
+  readability-identifier-naming.StaticConstantPrefix: "c"
+
+  # Naming rules for constants that can be determined at runtime
+  readability-identifier-naming.ConstantMemberCase: "lower_case"
+  # NOTE: We set this to ensure it doesn't default to `MemberPrefix`
+  readability-identifier-naming.ConstantMemberPrefix: ""
+  readability-identifier-naming.ConstantParameterCase: "lower_case"
+  readability-identifier-naming.ConstantPointerParameterCase: "lower_case"
+  readability-identifier-naming.LocalConstantCase: "lower_case"
+  readability-identifier-naming.LocalConstantPointerCase: "lower_case"
+
+  # Variable naming rules
+  readability-identifier-naming.GlobalPointerCase: "lower_case"
+  readability-identifier-naming.GlobalVariableCase: "lower_case"
+  readability-identifier-naming.LocalPointerCase: "lower_case"
+  readability-identifier-naming.LocalVariableCase: "lower_case"
+  readability-identifier-naming.StaticVariableCase: "lower_case"
+  readability-identifier-naming.VariableCase: "lower_case"
+
+
+  # Class member naming rules
+  readability-identifier-naming.ClassMemberCase: "lower_case"
+  # NOTE: We set this in case it doesn't default to `MemberPrefix`
+  readability-identifier-naming.ClassMemberPrefix: "m_"
+  readability-identifier-naming.MemberCase: "lower_case"
+  readability-identifier-naming.MemberPrefix: "m_"
+  readability-identifier-naming.PrivateMemberCase: "lower_case"
+  readability-identifier-naming.PrivateMemberPrefix: "m_"
+  readability-identifier-naming.ProtectedMemberCase: "lower_case"
+  readability-identifier-naming.ProtectedMemberPrefix: "m_"
+  readability-identifier-naming.PublicMemberCase: "lower_case"
+  readability-identifier-naming.PublicMemberPrefix: ""
+
+  # Concept naming rules
+  readability-identifier-naming.ConceptCase: "CamelCase"
+
+  # Parameter naming rules
+  readability-identifier-naming.ParameterCase: "lower_case"
+  readability-identifier-naming.ParameterPackCase: "lower_case"
+  readability-identifier-naming.PointerParameterCase: "lower_case"
+  readability-identifier-naming.TemplateParameterCase: "lower_case"
+  readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
+  readability-identifier-naming.ValueTemplateParameterCase: "lower_case"
+
+  # Function naming rules
+  readability-identifier-naming.ClassMethodCase: "lower_case"
+  readability-identifier-naming.ConstexprFunctionCase: "lower_case"
+  readability-identifier-naming.ConstexprMethodCase: "lower_case"
+  readability-identifier-naming.FunctionCase: "lower_case"
+  readability-identifier-naming.GlobalFunctionCase: "lower_case"
+  readability-identifier-naming.MethodCase: "lower_case"
+  readability-identifier-naming.PrivateMethodCase: "lower_case"
+  readability-identifier-naming.ProtectedMethodCase: "lower_case"
+  readability-identifier-naming.PublicMethodCase: "lower_case"
+  readability-identifier-naming.VirtualMethodCase: "lower_case"
+
+  # Enum naming rules
+  readability-identifier-naming.EnumCase: "CamelCase"
+  readability-identifier-naming.EnumConstantCase: "CamelCase"
+  readability-identifier-naming.ScopedEnumConstantCase: "CamelCase"
+
+  # Type naming rules
+  readability-identifier-naming.TypeAliasCase: "CamelCase"
+  readability-identifier-naming.TypeAliasIgnoredRegexp: "[0-9a-z_]+_t"
+  readability-identifier-naming.TypedefCase: "CamelCase"
+  readability-identifier-naming.TypedefIgnoredRegexp: "[0-9a-z_]+_t"
+  readability-identifier-naming.TypeTemplateParameterCase: "CamelCase"
+  readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: "[0-9a-z_]+_t"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -61,31 +61,6 @@ CheckOptions:
   readability-identifier-naming.EnumConstantCase: "CamelCase"
   readability-identifier-naming.ScopedEnumConstantCase: "CamelCase"
 
-  # Constexpr naming rules
-  readability-identifier-naming.ConstexprVariableCase: "CamelCase"
-  readability-identifier-naming.ConstexprVariablePrefix: "c"
-
-  # Constant naming rules
-  readability-identifier-naming.ClassConstantCase: "CamelCase"
-  readability-identifier-naming.ClassConstantPrefix: "c"
-  readability-identifier-naming.ConstantCase: "CamelCase"
-  readability-identifier-naming.ConstantPrefix: "c"
-  readability-identifier-naming.GlobalConstantCase: "CamelCase"
-  readability-identifier-naming.GlobalConstantPrefix: "c"
-  readability-identifier-naming.GlobalConstantPointerCase: "CamelCase"
-  readability-identifier-naming.GlobalConstantPointerPrefix: "c"
-  readability-identifier-naming.StaticConstantCase: "CamelCase"
-  readability-identifier-naming.StaticConstantPrefix: "c"
-
-  # Naming rules for constants that can be determined at runtime
-  readability-identifier-naming.ConstantMemberCase: "lower_case"
-  # NOTE: We set this to ensure it doesn't default to `MemberPrefix`
-  readability-identifier-naming.ConstantMemberPrefix: ""
-  readability-identifier-naming.ConstantParameterCase: "lower_case"
-  readability-identifier-naming.ConstantPointerParameterCase: "lower_case"
-  readability-identifier-naming.LocalConstantCase: "lower_case"
-  readability-identifier-naming.LocalConstantPointerCase: "lower_case"
-
   # Class naming rules
   readability-identifier-naming.AbstractClassCase: "CamelCase"
   readability-identifier-naming.ClassCase: "CamelCase"
@@ -110,6 +85,31 @@ CheckOptions:
   readability-identifier-naming.TemplateParameterCase: "lower_case"
   readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
   readability-identifier-naming.ValueTemplateParameterCase: "lower_case"
+
+  # Constexpr naming rules
+  readability-identifier-naming.ConstexprVariableCase: "CamelCase"
+  readability-identifier-naming.ConstexprVariablePrefix: "c"
+
+  # Constant naming rules
+  readability-identifier-naming.ClassConstantCase: "CamelCase"
+  readability-identifier-naming.ClassConstantPrefix: "c"
+  readability-identifier-naming.ConstantCase: "CamelCase"
+  readability-identifier-naming.ConstantPrefix: "c"
+  readability-identifier-naming.GlobalConstantCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantPrefix: "c"
+  readability-identifier-naming.GlobalConstantPointerCase: "CamelCase"
+  readability-identifier-naming.GlobalConstantPointerPrefix: "c"
+  readability-identifier-naming.StaticConstantCase: "CamelCase"
+  readability-identifier-naming.StaticConstantPrefix: "c"
+
+  # Naming rules for constants that can be determined at runtime
+  readability-identifier-naming.ConstantMemberCase: "lower_case"
+  # NOTE: We set this to ensure it doesn't default to `MemberPrefix`
+  readability-identifier-naming.ConstantMemberPrefix: ""
+  readability-identifier-naming.ConstantParameterCase: "lower_case"
+  readability-identifier-naming.ConstantPointerParameterCase: "lower_case"
+  readability-identifier-naming.LocalConstantCase: "lower_case"
+  readability-identifier-naming.LocalConstantPointerCase: "lower_case"
 
   # Class member naming rules
   readability-identifier-naming.ClassMemberCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -53,11 +53,6 @@ CheckOptions:
   # Concept naming rules
   readability-identifier-naming.ConceptCase: "CamelCase"
 
-  # Class naming rules
-  readability-identifier-naming.AbstractClassCase: "CamelCase"
-  readability-identifier-naming.ClassCase: "CamelCase"
-  readability-identifier-naming.StructCase: "CamelCase"
-
   # Union naming rules
   readability-identifier-naming.UnionCase: "CamelCase"
 
@@ -90,6 +85,11 @@ CheckOptions:
   readability-identifier-naming.ConstantPointerParameterCase: "lower_case"
   readability-identifier-naming.LocalConstantCase: "lower_case"
   readability-identifier-naming.LocalConstantPointerCase: "lower_case"
+
+  # Class naming rules
+  readability-identifier-naming.AbstractClassCase: "CamelCase"
+  readability-identifier-naming.ClassCase: "CamelCase"
+  readability-identifier-naming.StructCase: "CamelCase"
 
   # Variable naming rules
   readability-identifier-naming.GlobalPointerCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -42,6 +42,14 @@ CheckOptions:
   readability-identifier-naming.NamespaceCase: "lower_case"
   readability-identifier-naming.InlineNamespaceCase: "lower_case"
 
+  # Type naming rules
+  readability-identifier-naming.TypeAliasCase: "CamelCase"
+  readability-identifier-naming.TypeAliasIgnoredRegexp: "[0-9a-z_]+_t"
+  readability-identifier-naming.TypedefCase: "CamelCase"
+  readability-identifier-naming.TypedefIgnoredRegexp: "[0-9a-z_]+_t"
+  readability-identifier-naming.TypeTemplateParameterCase: "CamelCase"
+  readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: "[0-9a-z_]+_t"
+
   # Class naming rules
   readability-identifier-naming.AbstractClassCase: "CamelCase"
   readability-identifier-naming.ClassCase: "CamelCase"
@@ -124,11 +132,3 @@ CheckOptions:
   readability-identifier-naming.EnumCase: "CamelCase"
   readability-identifier-naming.EnumConstantCase: "CamelCase"
   readability-identifier-naming.ScopedEnumConstantCase: "CamelCase"
-
-  # Type naming rules
-  readability-identifier-naming.TypeAliasCase: "CamelCase"
-  readability-identifier-naming.TypeAliasIgnoredRegexp: "[0-9a-z_]+_t"
-  readability-identifier-naming.TypedefCase: "CamelCase"
-  readability-identifier-naming.TypedefIgnoredRegexp: "[0-9a-z_]+_t"
-  readability-identifier-naming.TypeTemplateParameterCase: "CamelCase"
-  readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: "[0-9a-z_]+_t"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -50,6 +50,9 @@ CheckOptions:
   readability-identifier-naming.TypeTemplateParameterCase: "CamelCase"
   readability-identifier-naming.TypeTemplateParameterIgnoredRegexp: "[0-9a-z_]+_t"
 
+  # Concept naming rules
+  readability-identifier-naming.ConceptCase: "CamelCase"
+
   # Class naming rules
   readability-identifier-naming.AbstractClassCase: "CamelCase"
   readability-identifier-naming.ClassCase: "CamelCase"
@@ -104,9 +107,6 @@ CheckOptions:
   readability-identifier-naming.ProtectedMemberPrefix: "m_"
   readability-identifier-naming.PublicMemberCase: "lower_case"
   readability-identifier-naming.PublicMemberPrefix: ""
-
-  # Concept naming rules
-  readability-identifier-naming.ConceptCase: "CamelCase"
 
   # Parameter naming rules
   readability-identifier-naming.ParameterCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -91,6 +91,18 @@ CheckOptions:
   readability-identifier-naming.ClassCase: "CamelCase"
   readability-identifier-naming.StructCase: "CamelCase"
 
+  # Function naming rules
+  readability-identifier-naming.ClassMethodCase: "lower_case"
+  readability-identifier-naming.ConstexprFunctionCase: "lower_case"
+  readability-identifier-naming.ConstexprMethodCase: "lower_case"
+  readability-identifier-naming.FunctionCase: "lower_case"
+  readability-identifier-naming.GlobalFunctionCase: "lower_case"
+  readability-identifier-naming.MethodCase: "lower_case"
+  readability-identifier-naming.PrivateMethodCase: "lower_case"
+  readability-identifier-naming.ProtectedMethodCase: "lower_case"
+  readability-identifier-naming.PublicMethodCase: "lower_case"
+  readability-identifier-naming.VirtualMethodCase: "lower_case"
+
   # Variable naming rules
   readability-identifier-naming.GlobalPointerCase: "lower_case"
   readability-identifier-naming.GlobalVariableCase: "lower_case"
@@ -120,15 +132,3 @@ CheckOptions:
   readability-identifier-naming.TemplateParameterCase: "lower_case"
   readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
   readability-identifier-naming.ValueTemplateParameterCase: "lower_case"
-
-  # Function naming rules
-  readability-identifier-naming.ClassMethodCase: "lower_case"
-  readability-identifier-naming.ConstexprFunctionCase: "lower_case"
-  readability-identifier-naming.ConstexprMethodCase: "lower_case"
-  readability-identifier-naming.FunctionCase: "lower_case"
-  readability-identifier-naming.GlobalFunctionCase: "lower_case"
-  readability-identifier-naming.MethodCase: "lower_case"
-  readability-identifier-naming.PrivateMethodCase: "lower_case"
-  readability-identifier-naming.ProtectedMethodCase: "lower_case"
-  readability-identifier-naming.PublicMethodCase: "lower_case"
-  readability-identifier-naming.VirtualMethodCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -111,15 +111,6 @@ CheckOptions:
   readability-identifier-naming.TemplateTemplateParameterCase: "lower_case"
   readability-identifier-naming.ValueTemplateParameterCase: "lower_case"
 
-  # Variable naming rules
-  readability-identifier-naming.GlobalPointerCase: "lower_case"
-  readability-identifier-naming.GlobalVariableCase: "lower_case"
-  readability-identifier-naming.LocalPointerCase: "lower_case"
-  readability-identifier-naming.LocalVariableCase: "lower_case"
-  readability-identifier-naming.StaticVariableCase: "lower_case"
-  readability-identifier-naming.VariableCase: "lower_case"
-
-
   # Class member naming rules
   readability-identifier-naming.ClassMemberCase: "lower_case"
   # NOTE: We set this in case it doesn't default to `MemberPrefix`
@@ -132,3 +123,11 @@ CheckOptions:
   readability-identifier-naming.ProtectedMemberPrefix: "m_"
   readability-identifier-naming.PublicMemberCase: "lower_case"
   readability-identifier-naming.PublicMemberPrefix: ""
+
+  # Variable naming rules
+  readability-identifier-naming.GlobalPointerCase: "lower_case"
+  readability-identifier-naming.GlobalVariableCase: "lower_case"
+  readability-identifier-naming.LocalPointerCase: "lower_case"
+  readability-identifier-naming.LocalVariableCase: "lower_case"
+  readability-identifier-naming.StaticVariableCase: "lower_case"
+  readability-identifier-naming.VariableCase: "lower_case"

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -61,6 +61,11 @@ CheckOptions:
   # Union naming rules
   readability-identifier-naming.UnionCase: "CamelCase"
 
+  # Enum naming rules
+  readability-identifier-naming.EnumCase: "CamelCase"
+  readability-identifier-naming.EnumConstantCase: "CamelCase"
+  readability-identifier-naming.ScopedEnumConstantCase: "CamelCase"
+
   # Constexpr naming rules
   readability-identifier-naming.ConstexprVariableCase: "CamelCase"
   readability-identifier-naming.ConstexprVariablePrefix: "c"
@@ -127,8 +132,3 @@ CheckOptions:
   readability-identifier-naming.ProtectedMethodCase: "lower_case"
   readability-identifier-naming.PublicMethodCase: "lower_case"
   readability-identifier-naming.VirtualMethodCase: "lower_case"
-
-  # Enum naming rules
-  readability-identifier-naming.EnumCase: "CamelCase"
-  readability-identifier-naming.EnumConstantCase: "CamelCase"
-  readability-identifier-naming.ScopedEnumConstantCase: "CamelCase"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This config is similar to one we've been using in [clp-ffi-go](https://github.com/y-scope/clp-ffi-go/blob/main/cpp/.clang-tidy). The main differences are it's more explicit about several rules for the reasons explained in the file itself, and it adds more comments.

NOTE: Some parts of the file should be reordered but they've been left as is so that it's easier to diff the one from clp-ffi-go. After review, we will reorder things before re-reviewing and merging.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated that clp-ffi-go continued to pass clang-tidy with the config from this PR.