### PR TITLE
Add clang-format config.

### DIFF
--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -1,0 +1,149 @@
+# yamllint disable-line rule:document-start
+---
+ColumnLimit: 100
+IndentWidth: 4
+# yamllint disable-line rule:document-start
+---
+Language: "Cpp"
+AccessModifierOffset: -4
+AlignAfterOpenBracket: "BlockIndent"
+AlignArrayOfStructures: "None"
+AlignConsecutiveAssignments: "None"
+AlignConsecutiveBitFields: "None"
+AlignConsecutiveDeclarations: "None"
+AlignConsecutiveMacros: "None"
+AlignEscapedNewlines: "DontAlign"
+AlignOperands: "Align"
+AlignTrailingComments:
+  Kind: "Never"
+AllowAllArgumentsOnNextLine: false
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
+AllowShortBlocksOnASingleLine: "Always"
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: "Inline"
+AllowShortIfStatementsOnASingleLine: "Never"
+AllowShortLambdasOnASingleLine: "All"
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterReturnType: "None"
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: "Yes"
+BinPackArguments: false
+BinPackParameters: false
+BitFieldColonSpacing: "Both"
+BraceWrapping:
+  AfterCaseLabel: false
+  AfterClass: false
+  AfterControlStatement: "MultiLine"
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterExternBlock: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  BeforeLambdaBody: false
+  BeforeWhile: false
+  IndentBraces: false
+  SplitEmptyFunction: false
+  SplitEmptyNamespace: false
+  SplitEmptyRecord: false
+BreakAfterAttributes: "Never"
+BreakBeforeBinaryOperators: "All"
+BreakBeforeBraces: "Custom"
+BreakBeforeConceptDeclarations: "Always"
+BreakBeforeInlineASMColon: "OnlyMultiline"
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: "BeforeColon"
+BreakInheritanceList: "BeforeColon"
+BreakStringLiterals: true
+CompactNamespaces: true
+ConstructorInitializerIndentWidth: 8
+ContinuationIndentWidth: 8
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat: false
+EmptyLineAfterAccessModifier: "Never"
+EmptyLineBeforeAccessModifier: "LogicalBlock"
+FixNamespaceComments: true
+IncludeBlocks: "Regroup"
+IndentAccessModifiers: false
+IndentCaseBlocks: false
+IndentCaseLabels: true
+IndentExternBlock: "Indent"
+IndentGotoLabels: false
+IndentPPDirectives: "BeforeHash"
+IndentRequiresClause: false
+IndentWrappedFunctionNames: false
+InsertBraces: true
+InsertNewlineAtEOF: true
+IntegerLiteralSeparator:
+  Binary: 4
+  BinaryMinDigits: 4
+  Decimal: 3
+  DecimalMinDigits: 5
+  Hex: 4
+  HexMinDigits: 4
+KeepEmptyLinesAtTheStartOfBlocks: false
+LambdaBodyIndentation: "Signature"
+LineEnding: "LF"
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: "None"
+PPIndentWidth: -1
+PackConstructorInitializers: "CurrentLine"
+PenaltyBreakOpenParenthesis: 25
+PenaltyBreakBeforeFirstCallParameter: 25
+PenaltyReturnTypeOnItsOwnLine: 100
+PointerAlignment: "Left"
+QualifierAlignment: "Custom"
+QualifierOrder:
+  - "static"
+  - "friend"
+  - "inline"
+  # constexpr west as explained in https://www.youtube.com/watch?v=z6s6bacI424
+  - "constexpr"
+  - "type"
+  - "const"
+  - "volatile"
+ReferenceAlignment: "Pointer"
+ReflowComments: true
+RemoveBracesLLVM: false
+RemoveSemicolon: true
+RequiresClausePosition: "OwnLine"
+RequiresExpressionIndentation: "OuterScope"
+SeparateDefinitionBlocks: "Always"
+ShortNamespaceLines: 0
+SortIncludes: "CaseInsensitive"
+SortUsingDeclarations: "Lexicographic"
+SpaceAfterCStyleCast: false
+SpaceAfterLogicalNot: false
+SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: "Default"
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: "ControlStatements"
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles: false
+SpacesInContainerLiterals: false
+SpacesInLineCommentPrefix:
+  Minimum: 1
+  Maximum: -1
+SpacesInParens: "Custom"
+SpacesInParensOptions:
+  InConditionalStatements: false
+  InCStyleCasts: false
+  InEmptyParentheses: false
+  Other: false
+SpacesInSquareBrackets: false
+Standard: "Latest"
+TabWidth: 4
+UseTab: "Never"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This config is identical to the one we've been using in [clp](https://github.com/y-scope/clp/blob/main/components/core/.clang-format) except it doesn't include the option to set the `IncludeCategories` since that's project-specific.

To use it in a project, devs should:

1. Add a setup step to symlink `.clang-format` to the project root.
2. Add a project-specific `.clang-format` file in a subdirectory where it should apply (e.g., `src`).
3. In the project-specific `.clang-format` file:
    * Set `BasedOnStyle: InheritParentConfig` to inherit from config file in the parent directory.
    * Set `IncludeCategories` for as necessary.

For example:

```yaml
# .clang-format
BasedOnStyle: InheritParentConfig

IncludeCategories:
  # NOTE: A header is grouped by first matching regex
  # Library headers. Update when adding new libraries.
  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
  - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|json|log_surgeon|mariadb\
|mongocxx|msgpack|openssl|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils|yaml-cpp|zstd)"
    Priority: 3
  # C system headers
  - Regex: "^<.+\\.h>"
    Priority: 1
  # C++ standard libraries
  - Regex: "^<.+>"
    Priority: 2
  # Project headers
  - Regex: "^\".+\""
    Priority: 4
```

These instructions will be added to a doc in a subsequent PR.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated that clp continued to pass clang-format with the config from this PR combined with a project-specific `.clang-format`.