### PR TITLE
taskfiles: Add support for excluding paths in checksumming utilities.

### DIFF
--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -3,10 +3,11 @@ version: "3"
 tasks:
   # ===
   # CHECKSUM UTILS
+  # ===
+
   # @param {string} DATA_DIR The directory to compute the checksum for.
   # @param {string} OUTPUT_FILE
   # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
-  # ===
   compute-checksum:
     desc: "Tries to compute a checksum for the given directory and output it to a file."
     internal: true
@@ -30,6 +31,9 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
+  # @param {string} DATA_DIR The directory to compute the checksum for.
+  # @param {string} OUTPUT_FILE
+  # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -10,6 +10,18 @@ tasks:
     silent: true
     requires:
       vars: ["DATA_DIR", "OUTPUT_FILE"]
+    vars:
+      # When the task is called with EXCLUDE_PATHS being a list, concatenate the items into a comma (",") separated
+      # string. This is needed because go-task does not support passing array variables from one task's argument into
+      # another task.
+      EXCLUDE_PATHS: >-
+        {{- if eq (typeOf .EXCLUDE_PATHS) "[]interface {}"}}
+          {{- range .EXCLUDE_PATHS}}
+            {{- .}},
+          {{- end}}
+        {{- else}}
+          {{- .EXCLUDE_PATHS}}
+        {{- end}}
     cmds:
       - >-
         tar cf -
@@ -19,6 +31,11 @@ tasks:
         --numeric-owner
         --owner 0
         --sort name
+        {{- range (.EXCLUDE_PATHS | split ",")}}
+        {{- if .}}
+        --exclude="{{.}}"
+        {{- end}}
+        {{- end}}
         . 2> /dev/null
         | md5sum > {{.OUTPUT_FILE}}
     # Ignore errors so that dependent tasks don't fail
@@ -37,6 +54,12 @@ tasks:
       - task: "compute-checksum"
         vars:
           DATA_DIR: "{{.DATA_DIR}}"
+          # Concatenate the EXCLUDE_PATHS items into a comma (",") separated string. This is needed because go-task
+          # does not support passing array variables from one task's argument into another task.
+          EXCLUDE_PATHS: >-
+            {{- range .EXCLUDE_PATHS}}
+              {{- .}},
+            {{- end}}
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the directory exists and the checksum matches; otherwise delete the checksum file

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -10,18 +10,6 @@ tasks:
     silent: true
     requires:
       vars: ["DATA_DIR", "OUTPUT_FILE"]
-    vars:
-      # When the task is called with EXCLUDE_PATHS being a list, concatenate the items into a comma (",") separated
-      # string. This is needed because go-task does not support passing array variables from one task's argument into
-      # another task.
-      EXCLUDE_PATHS: >-
-        {{- if eq (typeOf .EXCLUDE_PATHS) "[]interface {}"}}
-          {{- range .EXCLUDE_PATHS}}
-            {{- .}},
-          {{- end}}
-        {{- else}}
-          {{- .EXCLUDE_PATHS}}
-        {{- end}}
     cmds:
       - >-
         tar cf -
@@ -31,10 +19,8 @@ tasks:
         --numeric-owner
         --owner 0
         --sort name
-        {{- range (.EXCLUDE_PATHS | split ",")}}
-        {{- if .}}
+        {{- range .EXCLUDE_PATHS}}
         --exclude="{{.}}"
-        {{- end}}
         {{- end}}
         . 2> /dev/null
         | md5sum > {{.OUTPUT_FILE}}
@@ -54,12 +40,8 @@ tasks:
       - task: "compute-checksum"
         vars:
           DATA_DIR: "{{.DATA_DIR}}"
-          # Concatenate the EXCLUDE_PATHS items into a comma (",") separated string. This is needed because go-task
-          # does not support passing array variables from one task's argument into another task.
-          EXCLUDE_PATHS: >-
-            {{- range .EXCLUDE_PATHS}}
-              {{- .}},
-            {{- end}}
+          EXCLUDE_PATHS:
+            ref: ".EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the directory exists and the checksum matches; otherwise delete the checksum file

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -31,7 +31,7 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
-  # @param {string} DATA_DIR The directory to compute the checksum for.
+  # @param {string} DATA_DIR The directory to validate the checksum for.
   # @param {string} OUTPUT_FILE
   # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
   validate-checksum:

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -3,6 +3,9 @@ version: "3"
 tasks:
   # ===
   # CHECKSUM UTILS
+  # @param {string} DATA_DIR The directory to compute the checksum for.
+  # @param {string} OUTPUT_FILE
+  # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
   # ===
   compute-checksum:
     desc: "Tries to compute a checksum for the given directory and output it to a file."


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
An issue was encountered when the checksumming utilities are used in a go-task Taskfile in clp-ffi-js https://github.com/y-scope/clp-ffi-js/pull/1 . The Taskfile downloads an SDK, calls task `compute-checksum`, and compiles some code with the SDK. However, during the compilation, there are cache files produced within the SDK directory. When developers reruns the Taskfile, checksum validation fails on the SDK directory and causes the SDK to be re-downloaded and the code to be re-compiled, which negates the effort to avoid unnecessary reprocessing.

This PR adds support for `EXCLUDE_PATHS` in checksumming utilities.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
1. Created an empty directory named `example`.
2. In the newly created directory, created test files and another directory with below structure:
   ```
   - example
     - Taskfile.yml (to be filled in the next step)
     - test
       - ignored
         - ignored_in_dir.txt
       - ignored_file.txt
       - important.txt
   ```
4. Filled Taskfile.yml with below content.
    ```yaml
    version: '3'
    
    includes:
      utils: "utils.yml"
    
    tasks:
      default:
        vars:
          BUILD_DIR: "test"
          OUTPUT_FILE: "checksum.txt"
        cmds:
          - task: "utils:validate-checksum"
            vars:
              CHECKSUM_FILE: "{{.OUTPUT_FILE}}"
              DATA_DIR: "{{.BUILD_DIR}}"
              EXCLUDE_PATHS: &test_excluded_paths
                - "ignored"
                - "ignored_file.txt"
          - task: "utils:compute-checksum"
            vars:
              DATA_DIR: "{{.BUILD_DIR}}"
              OUTPUT_FILE: "{{.OUTPUT_FILE}}"
              EXCLUDE_PATHS: *test_excluded_paths
          - "cat {{.OUTPUT_FILE}}"
          - "date > {{.BUILD_DIR}}/ignored/ignored_in_dir.txt"
          - "date > {{.BUILD_DIR}}/ignored_file.txt"
    ```
5. Ran `task` twice and did not observed "Files checksum.txt.tmp and checksum.txt differ".
6. Modified `example/test/important.txt`, ran task and observed "Files checksum.txt.tmp and checksum.txt differ".