### PR TITLE
Add docs and scripts for using `yscope-dev-utils` and the C++ linting configs.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -4,17 +4,17 @@ This repo contains configs, scripts, and tools that are reusable across all our 
 
 ## Usage
 
-To use the artifacts in this repo in your project:
+To use the repo's artifacts in your project:
 
 1. Add `yscope-dev-utils` as a submodule in your project:
    ```shell
    git submodule add https://github.com/y-scope/yscope-dev-utils.git tools/yscope-dev-utils
    ```
-2. Add a setup step to check out the submodule:
+2. Add a setup step (to the project's setup script or docs) to check out the submodule:
    ```shell
    git submodule update --init --recursive tools/yscope-dev-utils
    ```
-3. Use the artifacts in your project as needed.
+3. Use the artifacts as needed.
 
 For language/tool-specific guides, see:
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,21 @@
+# yscope-dev-utils
+
+This repo contains configs, scripts, and tools that are reusable across all our repos.
+
+## Usage
+
+To use the artifacts in this repo in your project:
+
+1. Add `yscope-dev-utils` as a submodule in your project:
+   ```shell
+   git submodule add https://github.com/y-scope/yscope-dev-utils.git tools/yscope-dev-utils
+   ```
+2. Add a setup step to check out the submodule:
+   ```shell
+   git submodule update --init --recursive tools/yscope-dev-utils
+   ```
+3. Use the artifacts in your project as needed.
+
+For language/tool-specific guides, see:
+
+* [Linting for C++ projects](lint-tools-cpp.md)

--- a/docs/lint-tools-cpp.md
+++ b/docs/lint-tools-cpp.md
@@ -5,10 +5,10 @@ We use `clang-format` for formatting and `clang-tidy` for code analysis.
 ## General usage
 
 C++ projects should use the [.clang-format] and [.clang-tidy] config files as follows (assuming
-`yscope-dev-utils` was added at `tools/yscope-dev-utils` in the project):
+`yscope-dev-utils` was added to the project at `tools/yscope-dev-utils`):
 
 1. Add a setup step to symlink the files to the project root.
-   * You can use `yscope-dev-utils/scripts/symlink-cpp-lint-configs.sh`.
+   * You can use [symlink-cpp-lint-configs.sh].
 2. Create project-specific config files to override any settings as necessary (see below).
 3. Run `clang-format` and `clang-tidy` using the config files.
 
@@ -70,3 +70,4 @@ Checks: >-
 
 [.clang-format]: ../lint-configs/.clang-format
 [.clang-tidy]: ../lint-configs/.clang-tidy
+[symlink-cpp-lint-configs.sh]: ../lint-configs/symlink-cpp-lint-configs.sh

--- a/docs/lint-tools-cpp.md
+++ b/docs/lint-tools-cpp.md
@@ -23,8 +23,8 @@ C++ projects should use the [.clang-format] and [.clang-tidy] config files as fo
 
 In the project-specific config file:
 
-* Set `BasedOnStyle: InheritParentConfig` to inherit from config file in the parent directory.
-* Set `IncludeCategories` for as necessary.
+* Set `BasedOnStyle: InheritParentConfig` to inherit from the config file at the project's root.
+* Set `IncludeCategories` as necessary.
 
 For example:
 
@@ -53,8 +53,8 @@ IncludeCategories:
 
 In the project-specific config file:
 
-* Set `InheritParentConfig: true` to inherit from config file in the parent directory.
-* Update, add, or disable checks for the project as necessary.
+* Set `InheritParentConfig: true` to inherit from the config file at the project's root.
+* Update, add, or disable checks as necessary.
   * For any disabled or added checks, add a comment explaining why.
 
 For example:
@@ -63,7 +63,7 @@ For example:
 InheritParentConfig: true
 
 # Disabled checks:
-# - `cppcoreguidelines-avoid-non-const-global-variables` because 
+# - `cppcoreguidelines-avoid-non-const-global-variables` because ...
 Checks: >-
   -cppcoreguidelines-avoid-non-const-global-variables,
 ```

--- a/docs/lint-tools-cpp.md
+++ b/docs/lint-tools-cpp.md
@@ -1,0 +1,72 @@
+# Linting for C++ projects
+
+We use `clang-format` for formatting and `clang-tidy` for code analysis.
+
+## General usage
+
+C++ projects should use the [.clang-format] and [.clang-tidy] config files as follows (assuming
+`yscope-dev-utils` was added at `tools/yscope-dev-utils` in the project):
+
+1. Add a setup step to symlink the files to the project root.
+   * You can use `yscope-dev-utils/scripts/symlink-cpp-lint-configs.sh`.
+2. Create project-specific config files to override any settings as necessary (see below).
+3. Run `clang-format` and `clang-tidy` using the config files.
+
+## Creating project-specific config files
+
+* Create a `.clang-format` or `.clang-tidy` file in the project subdirectory (e.g. `src`) where the
+  settings are necessary.
+* In each config file, set the relevant option (see the tool-specific sections below) to inherit
+  from the config file in the parent directory.
+
+### clang-format
+
+In the project-specific config file:
+
+* Set `BasedOnStyle: InheritParentConfig` to inherit from config file in the parent directory.
+* Set `IncludeCategories` for as necessary.
+
+For example:
+
+```yaml
+BasedOnStyle: InheritParentConfig
+
+IncludeCategories:
+  # NOTE: A header is grouped by first matching regex
+  # Library headers. Update when adding new libraries.
+  # NOTE: clang-format retains leading white-space on a line in violation of the YAML spec.
+  - Regex: "<(absl|antlr4|archive|boost|bsoncxx|catch2|curl|date|fmt|json|log_surgeon|mariadb\
+|mongocxx|msgpack|openssl|outcome|regex_utils|simdjson|spdlog|sqlite3|string_utils|yaml-cpp|zstd)"
+    Priority: 3
+  # C system headers
+  - Regex: "^<.+\\.h>"
+    Priority: 1
+  # C++ standard libraries
+  - Regex: "^<.+>"
+    Priority: 2
+  # Project headers
+  - Regex: "^\".+\""
+    Priority: 4
+```
+
+### clang-tidy
+
+In the project-specific config file:
+
+* Set `InheritParentConfig: true` to inherit from config file in the parent directory.
+* Update, add, or disable checks for the project as necessary.
+  * For any disabled or added checks, add a comment explaining why.
+
+For example:
+
+```yaml
+InheritParentConfig: true
+
+# Disabled checks:
+# - `cppcoreguidelines-avoid-non-const-global-variables` because 
+Checks: >-
+  -cppcoreguidelines-avoid-non-const-global-variables,
+```
+
+[.clang-format]: ../lint-configs/.clang-format
+[.clang-tidy]: ../lint-configs/.clang-tidy

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -11,7 +11,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # Symlinks the given config file to the repo's root.
 #
 # @param $1 Path to the config file in the repo.
-function symlink_config () {
+symlink_config () {
     config_file_path="$1"
 
     repo_dir="$(git rev-parse --show-toplevel)"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -11,7 +11,7 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Symlinks the given config file to the repo's root.
 #
-# * @param $1 Path to the config file in the repo.
+# @param $1 Path to the config file in the repo.
 function symlink_config () {
     config_file_path="$1"
 

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -32,5 +32,9 @@ function symlink_config () {
     fi
 }
 
-symlink_config "${script_dir}/.clang-format"
-symlink_config "${script_dir}/.clang-tidy"
+main () {
+    symlink_config "${script_dir}/.clang-format"
+    symlink_config "${script_dir}/.clang-tidy"
+}
+
+main "$@"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -6,7 +6,6 @@ set -e
 # Error on undefined variable
 set -u
 
-repo_dir="$(git rev-parse --show-toplevel)"
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
 # Symlinks the given config file to the repo's root.

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -37,11 +37,7 @@ symlink_config () {
 
 main () {
     symlink_config "${script_dir}/.clang-format"
-    ret_val=$?
     symlink_config "${script_dir}/.clang-tidy"
-    ret_val=$((ret_val || $?))
-
-    return $ret_val
 }
 
 main "$@"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -27,14 +27,21 @@ function symlink_config () {
         echo "Symlinked '${src_path}' to '${dst_path}'."
     elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
         echo "Unknown config file exists at '${dst_path}'. Remove it before running this script."
+        return 1
     else
         echo "Already symlinked '${src_path}' to '${dst_path}'."
     fi
+
+    return 0
 }
 
 main () {
     symlink_config "${script_dir}/.clang-format"
+    ret_val=$?
     symlink_config "${script_dir}/.clang-tidy"
+    ret_val=$((ret_val || $?))
+
+    return $ret_val
 }
 
 main "$@"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+repo_dir="$(git rev-parse --show-toplevel)"
+script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+function symlink_config () {
+    src_path="$1"
+    dst_path="$2"
+
+    if [ ! -e "$dst_path" ]; then
+        ln -s "$src_path" "$clang_tidy_config_dst"
+    else
+        if [ "$(readlink -f "$clang_tidy_config_dst")" != "$(readlink -f "$clang_tidy_config_src")" ];
+        then
+            echo "Unexpected clang-tidy config at $clang_tidy_config_dst"
+        fi
+    fi
+}
+
+clang_tidy_config_dst="${repo_dir}/.clang-tidy"
+if [ ! -e "$clang_tidy_config_dst" ]; then
+    ln -s "$clang_tidy_config_src_relative_to_repo" "$clang_tidy_config_dst"
+else
+    if [ "$(readlink -f "$clang_tidy_config_dst")" != "$(readlink -f "$clang_tidy_config_src")" ];
+    then
+        echo "Unexpected clang-tidy config at $clang_tidy_config_dst"
+    fi
+fi

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -24,8 +24,11 @@ function symlink_config () {
     # `-L`.
     if [ ! -e "$dst_path" ] && [ ! -L "$dst_path" ]; then
         ln -s "$repo_relative_config_file_path" "$dst_path"
+        echo "Symlinked '${src_path}' to '${dst_path}'."
     elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
         echo "Unknown config file exists at '${dst_path}'. Remove it before running this script."
+    else
+        echo "Already symlinked '${src_path}' to '${dst_path}'."
     fi
 }
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds docs and scripts for:
* how to add `yscope-dev-utils` to a project; and
* how to use the C++ linting configs using inheritance rather than duplicating the config files.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Validated the docs looked good in the Markdown preview.
* Validated the linting symlink file works when run from a dependent project and is agnostic to the current working directory.
* Validated adding the cpp linting config files to [clp-ffi-py](https://github.com/y-scope/clp-ffi-py) and customizing the rules using the project-specific config steps in the docs.
