### PR TITLE
taskfiles: Clarify that `EXCLUDE_PATHS` are relative to the checksummed directory in the checksum-utils docstrings.

### DIFF
--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -7,7 +7,8 @@ tasks:
 
   # @param {string} DATA_DIR The directory to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
+  # @param {[]string} [EXCLUDE_PATHS] A list of paths, relative to `DATA_DIR`, to exclude from the
+  # checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given directory and output it to a file."
     internal: true
@@ -33,7 +34,8 @@ tasks:
 
   # @param {string} DATA_DIR The directory to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] A list of paths to exclude from the checksum.
+  # @param {[]string} [EXCLUDE_PATHS] A list of paths, relative to `DATA_DIR`, to exclude from the
+  # checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the PR title says.