### PR TITLE
symlink-cpp-lint-configs.sh: Replace `realpath` with equivalent to support macOS.

### DIFF
--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -17,10 +17,14 @@ symlink_config () {
     repo_dir="$(git rev-parse --show-toplevel)"
     config_file_absolute_path="$(readlink -f "$config_file_path")"
 
-    # NOTE: This is a bit fragile since it depends on adding a trailing slash to $repo_dir. Ideally,
-    # we would use `realpath --relative-to` instead of variable substitution, but `--relative-to`
-    # isn't available on macOS.
-    repo_relative_config_file_path="${config_file_absolute_path#"${repo_dir}/"}"
+    # Ensure $repo_dir has a single trailing slash
+    repo_dir="${repo_dir%/}/"
+
+    # Get the config file's path relative to the repo root
+    # NOTE: This is a bit fragile since it depends on $repo_dir having a single trailing slash.
+    # Ideally, we would use `realpath --relative-to` instead of variable substitution, but
+    # `--relative-to` isn't available on macOS.
+    repo_relative_config_file_path="${config_file_absolute_path#"${repo_dir}"}"
 
     src_path="${repo_dir}/${repo_relative_config_file_path}"
     dst_path="${repo_dir}/$(basename "$config_file_path")"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -15,7 +15,12 @@ symlink_config () {
     config_file_path="$1"
 
     repo_dir="$(git rev-parse --show-toplevel)"
-    repo_relative_config_file_path="$(realpath --relative-to="$repo_dir" "$config_file_path")"
+    config_file_absolute_path="$(readlink -f "$config_file_path")"
+
+    # NOTE: This is a bit fragile since it depends on adding a trailing slash to $repo_dir. Ideally,
+    # we would use `realpath --relative-to` instead of variable substitution, but `--relative-to`
+    # isn't available on macOS.
+    repo_relative_config_file_path="${config_file_absolute_path#"${repo_dir}/"}"
 
     src_path="${repo_dir}/${repo_relative_config_file_path}"
     dst_path="${repo_dir}/$(basename "$config_file_path")"


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

macOS doesn't support `realpath --relative-to` (even with the `coreutils` package installed), so this PR replaces the instance in `symlink-cpp-lint-configs.sh` with bash variable substitutions.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

Validated the new script worked on both Linux and macOS in a test run of the [clp-lint](https://github.com/kirkrodrigues/clp/actions/runs/10707509343/job/29687652025) workflow on my [fork](https://github.com/kirkrodrigues/clp/tree/cpp-lint-configs) of CLP. The branch follows the [docs](https://github.com/y-scope/yscope-dev-utils/blob/main/docs/lint-tools-cpp.md) to add the C++ lint configs to the CLP repo.