### PR TITLE
symlink-cpp-lint-configs.sh: Add argument handling for `symlink_config` and exit on error.

### DIFF
--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -14,13 +14,13 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 symlink_config () {
     if [ "$#" -ne 1 ]; then
         echo "Usage: symlink_config <config-file-path>"
-        exit 1
+        return 1
     fi
 
     config_file_path="$1"
     if [ ! -e "$config_file_path" ]; then
         echo "symlink_config: Config file doesn't exist: '$config_file_path'."
-        exit 1
+        return 1
     fi
 
     repo_dir="$(git rev-parse --show-toplevel)"
@@ -45,7 +45,7 @@ symlink_config () {
         echo "Symlinked '${src_path}' to '${dst_path}'."
     elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
         echo "Unknown config file exists at '${dst_path}'. Remove it before running this script."
-        exit 1
+        return 1
     else
         echo "Already symlinked '${src_path}' to '${dst_path}'."
     fi
@@ -54,8 +54,12 @@ symlink_config () {
 }
 
 main () {
-    symlink_config "${script_dir}/.clang-format"
-    symlink_config "${script_dir}/.clang-tidy"
+    if ! symlink_config "${script_dir}/.clang-format"; then
+        exit $?
+    fi
+    if ! symlink_config "${script_dir}/.clang-tidy"; then
+        exit $?
+    fi
 }
 
 main "$@"

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -13,13 +13,13 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # @param $1 Path to the config file in the repo.
 symlink_config () {
     if [ "$#" -ne 1 ]; then
-        echo "Usage: symlink_config <config-file-path>"
+        echo "Usage: symlink_config <config-file-path>" >&2
         return 1
     fi
 
     config_file_path="$1"
     if [ ! -f "$config_file_path" ]; then
-        echo "symlink_config: Config file doesn't exist: '$config_file_path'."
+        echo "symlink_config: Config file doesn't exist: '$config_file_path'." >&2
         return 1
     fi
 
@@ -44,7 +44,8 @@ symlink_config () {
         ln -s "$repo_relative_config_file_path" "$dst_path"
         echo "Symlinked '${src_path}' to '${dst_path}'."
     elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
-        echo "Unknown config file exists at '${dst_path}'. Remove it before running this script."
+        echo "Unknown config file exists at '${dst_path}'. Remove it before running this script." \
+            >&2
         return 1
     else
         echo "Already symlinked '${src_path}' to '${dst_path}'."

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -55,10 +55,10 @@ symlink_config () {
 
 main () {
     if ! symlink_config "${script_dir}/.clang-format"; then
-        exit $?
+        exit 1
     fi
     if ! symlink_config "${script_dir}/.clang-tidy"; then
-        exit $?
+        exit 1
     fi
 }
 

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -12,7 +12,16 @@ script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 #
 # @param $1 Path to the config file in the repo.
 symlink_config () {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: symlink_config <config-file-path>"
+        exit 1
+    fi
+
     config_file_path="$1"
+    if [ ! -e "$config_file_path" ]; then
+        echo "symlink_config: Config file doesn't exist: '$config_file_path'."
+        exit 1
+    fi
 
     repo_dir="$(git rev-parse --show-toplevel)"
     config_file_absolute_path="$(readlink -f "$config_file_path")"
@@ -36,7 +45,7 @@ symlink_config () {
         echo "Symlinked '${src_path}' to '${dst_path}'."
     elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
         echo "Unknown config file exists at '${dst_path}'. Remove it before running this script."
-        return 1
+        exit 1
     else
         echo "Already symlinked '${src_path}' to '${dst_path}'."
     fi

--- a/lint-configs/symlink-cpp-lint-configs.sh
+++ b/lint-configs/symlink-cpp-lint-configs.sh
@@ -18,7 +18,7 @@ symlink_config () {
     fi
 
     config_file_path="$1"
-    if [ ! -e "$config_file_path" ]; then
+    if [ ! -f "$config_file_path" ]; then
         echo "symlink_config: Config file doesn't exist: '$config_file_path'."
         return 1
     fi


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR adds validation for the arguments passed to `symlink_config` and explicitly checks the return status so that we can exit on error.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Validated `lint-configs/symlink-cpp-lint-configs.sh` ran successfully.
* Temporarily deleted `lint-configs/.clang-format` and validated that:
  * `lint-configs/symlink-cpp-lint-configs.sh` failed because the config file didn't exist.
  * the script's return status was 1.
* Temporarily created an empty `.clang-format` and validated that:
  * `lint-configs/symlink-cpp-lint-configs.sh` failed because it already existed and wasn't a symlink to `lint-configs/.clang-format`.
  * the script's return status was 1.
* Temporarily modified `lint-configs/symlink-cpp-lint-configs.sh` to call `symlink_config` without any arguments and with multiple arguments; validated that:
  * both failed because the number of arguments was wrong.
  * the script's return status was 1.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for configuration file symlinking, providing clearer user feedback.
	- Added validation for the number of arguments and existence of configuration files, enhancing usability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->