### PR TITLE
Update the clang-format config for clang-format v19.

### DIFF
--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -58,6 +58,7 @@ BreakBeforeConceptDeclarations: "Always"
 BreakBeforeInlineASMColon: "OnlyMultiline"
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: "BeforeColon"
+BreakFunctionDefinitionParameters: false
 BreakInheritanceList: "BeforeColon"
 BreakStringLiterals: true
 BreakTemplateDeclarations: "Yes"
@@ -94,6 +95,7 @@ KeepEmptyLines:
   AtStartOfFile: false
 LambdaBodyIndentation: "Signature"
 LineEnding: "LF"
+MainIncludeChar: "Quote"
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: "None"
 PPIndentWidth: -1

--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -20,7 +20,6 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
 AllowShortBlocksOnASingleLine: "Always"
-AllowShortCaseExpressionOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: false

--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -20,6 +20,7 @@ AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
 AllowShortBlocksOnASingleLine: "Always"
+AllowShortCaseExpressionOnASingleLine: false
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: false
@@ -27,9 +28,7 @@ AllowShortFunctionsOnASingleLine: "Inline"
 AllowShortIfStatementsOnASingleLine: "Never"
 AllowShortLambdasOnASingleLine: "All"
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterReturnType: "None"
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: "Yes"
 BinPackArguments: false
 BinPackParameters: false
 BitFieldColonSpacing: "Both"
@@ -52,6 +51,7 @@ BraceWrapping:
   SplitEmptyNamespace: false
   SplitEmptyRecord: false
 BreakAfterAttributes: "Never"
+BreakAfterReturnType: "Automatic"
 BreakBeforeBinaryOperators: "All"
 BreakBeforeBraces: "Custom"
 BreakBeforeConceptDeclarations: "Always"
@@ -60,6 +60,7 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: "BeforeColon"
 BreakInheritanceList: "BeforeColon"
 BreakStringLiterals: true
+BreakTemplateDeclarations: "Yes"
 CompactNamespaces: true
 ConstructorInitializerIndentWidth: 8
 ContinuationIndentWidth: 8
@@ -87,7 +88,10 @@ IntegerLiteralSeparator:
   DecimalMinDigits: 5
   Hex: 4
   HexMinDigits: 4
-KeepEmptyLinesAtTheStartOfBlocks: false
+KeepEmptyLines:
+  AtEndOfFile: true
+  AtStartOfBlock: false
+  AtStartOfFile: false
 LambdaBodyIndentation: "Signature"
 LineEnding: "LF"
 MaxEmptyLinesToKeep: 1
@@ -139,6 +143,7 @@ SpacesInLineCommentPrefix:
   Maximum: -1
 SpacesInParens: "Custom"
 SpacesInParensOptions:
+  ExceptDoubleParentheses: false
   InConditionalStatements: false
   InCStyleCasts: false
   InEmptyParentheses: false


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
clang-format just released version 19.1 in PyPI which affects some of our linting workflows (as mentioned in https://github.com/y-scope/clp/issues/545)
This PR updates the clang-format configuration to adapt the latest configuration changes:
- Deprecated options:
  - Replace `AlwaysBreakTemplateDeclarations` with the equivalent `BreakTemplateDeclarations`
  - Replace `AlwaysBreakAfterReturnType` with the equivalent `BreakAfterReturnType`
  - Use `KeepEmptyLines` to replace deprecated option `KeepEmptyLinesAtTheStartOfBlocks`, and also add a new line to the end of file (which is not set in the old config)
- New options introduced in clang-format 19:
  - Disable `AllowShortCaseExpressionOnASingleLine`
  - Diable `ExceptDoubleParentheses` under `SpacesInParensOptions`
  
References:
clang 19 release notes: https://releases.llvm.org/19.1.0/tools/clang/docs/ReleaseNotes.html#clang-format
clang-format 19 doc: https://releases.llvm.org/19.1.0/tools/clang/docs/

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Use the updated config to format clp core and ensure the lint task can be successfully executed. Manually verified the refactored code pieces didn't introduce any unexpected behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated formatting rules for improved code consistency and readability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->