### PR TITLE
Update clang-tidy config to disable signed char misuse checks for `int8_t`.

### DIFF
--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -25,6 +25,13 @@ Checks: >-
   -readability-simplify-boolean-expr,
 
 CheckOptions:
+  # These checks are intended to catch potentially bug-prone conversions from `signed char`  to
+  # larger integer types. However, these checks are only relevant when `signed char` is used to
+  # store character data. If a type like `int8_t` is used to represent signed integers, these checks
+  # can be safely skipped.
+  bugprone-signed-char-misuse.CharTypdefsToIgnore: "int8_t"
+  cert-str34-c.CharTypdefsToIgnore: "int8_t"
+
   # This is necessary to allow simple classes (with all members being public) that have a
   # constructor
   misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true

--- a/lint-configs/.clang-tidy
+++ b/lint-configs/.clang-tidy
@@ -25,10 +25,12 @@ Checks: >-
   -readability-simplify-boolean-expr,
 
 CheckOptions:
-  # These checks are intended to catch potentially bug-prone conversions from `signed char`  to
-  # larger integer types. However, these checks are only relevant when `signed char` is used to
-  # store character data. If a type like `int8_t` is used to represent signed integers, these checks
-  # can be safely skipped.
+  # These checks are intended to catch potentially bug-prone conversions from `signed char` to
+  # larger integer types, but are only relevant when `signed char` is used to store character data.
+  # If a type like `int8_t` is used to represent signed integers, these checks can be safely
+  # skipped.
+  #
+  # NOTE: The misspelling of "Typdef" is in clang's code.
   bugprone-signed-char-misuse.CharTypdefsToIgnore: "int8_t"
   cert-str34-c.CharTypdefsToIgnore: "int8_t"
 


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
clang-tidy provides checks to detect bug-prone signed char to integer conversion as explained in:
- https://clang.llvm.org/extra//clang-tidy/checks/bugprone/signed-char-misuse.html
- https://wiki.sei.cmu.edu/confluence/display/c/STR34-C.+Cast+characters+to+unsigned+char+before+converting+to+larger+integer+sizes

However, these checks are only applicable if the signed char represents a character data. If the signed char type is used to store integer data instead, the check won't make sense anymore. In our current project, we do have code pieces where we use `int8_t` (the underlying type of `char` or `signed char`) to store signed integer data. For example:  https://github.com/y-scope/clp/blob/7b921f156ce760989f9870385d5205531e488e3a/components/core/src/clp/ffi/ir_stream/Deserializer.cpp#L347.
In this case, our use case is irrelevant to the scenario mentioned on clang-tidy's menu page. Instead of manually disabling the check in the code, we will explicitly disable this check for `int8_t`.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
Tested on clp core with the updated config to ensure the clang-tidy warnings are silenced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated Clang-Tidy configuration to enhance coding standards.
	- Expanded `CheckOptions` to include specific handling for `int8_t` and organized checks into categories.
	- Standardized naming conventions for identifiers, detailing casing rules for macros, namespaces, types, and functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->