### PR TITLE
fix(taskfiles): Use empty list as default for optional task arguments passed via a `ref` (fixes 14).

### DIFF
--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -50,7 +50,7 @@ tasks:
         vars:
           DATA_DIR: "{{.DATA_DIR}}"
           EXCLUDE_PATHS:
-            ref: ".EXCLUDE_PATHS"
+            ref: "default (list) .EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the directory exists and the checksum matches; otherwise delete the checksum file


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As #14 describes, the behaviour of `task` has changed w.r.t. passing optional (undefined) variables via `ref`. It seems that `task` will now treat it as an empty string rather than leaving it as an undefined variable. Go is unhappy when trying to iterate over a variable which contains an empty string, but Go seems to skip iterating entirely if the variable is undefined.

I'll report this issue to the `task` devs, but in the meantime, this PR defines a default empty list for task parameters that we pass via the `ref` attribute.

# Validation performed
<!-- Describe what tests and validation you performed on the change. -->

* Installed task v3.40.0
* Validated `task lint:check` currently fails in `clp-ffi-js`
* Applied the fix in clp-ffi-js's yscope-dev-utils submodule.
* Validated `task lint:check` now succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the reference for the `EXCLUDE_PATHS` variable in the `validate-checksum` task for improved clarity.
	- No changes made to the core functionality of the `compute-checksum` task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->