### PR TITLE
feat(taskfiles): Add cmake and remote utils; Update checksum data path to an array.

### DIFF
--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -5,10 +5,10 @@ tasks:
   # CHECKSUM UTILS
   # ===
 
-  # @param {string} DATA_DIR The directory to compute the checksum for.
+  # @param {[]string} [DATA_PATHS] List of paths to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] A list of paths, relative to `DATA_DIR`, to exclude from the
-  # checksum.
+  # @param {[]string} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
+  # the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given directory and output it to a file."
     internal: true
@@ -18,7 +18,6 @@ tasks:
     cmds:
       - >-
         tar cf -
-        --directory "{{.DATA_DIR}}"
         --group 0
         --mtime "UTC 1970-01-01"
         --numeric-owner
@@ -27,15 +26,18 @@ tasks:
         {{- range .EXCLUDE_PATHS}}
         --exclude="{{.}}"
         {{- end}}
-        . 2> /dev/null
+        {{- range .DATA_PATHS}}
+        "{{.}}"
+        {{- end}}
+        2> /dev/null
         | md5sum > {{.OUTPUT_FILE}}
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
-  # @param {string} DATA_DIR The directory to validate the checksum for.
+  # @param {[]string} [DATA_PATHS] List of paths to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] A list of paths, relative to `DATA_DIR`, to exclude from the
-  # checksum.
+  # @param {[]string} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
+  # the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."
@@ -48,16 +50,19 @@ tasks:
     cmds:
       - task: "compute-checksum"
         vars:
-          DATA_DIR: "{{.DATA_DIR}}"
+          DATA_PATHS:
+            ref: ".DATA_PATHS"
           EXCLUDE_PATHS:
-            ref: "default (list) .EXCLUDE_PATHS"
+            ref: ".EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the directory exists and the checksum matches; otherwise delete the checksum file
       - >-
         (
-        test -d "{{.DATA_DIR}}"
-        && diff -q '{{.TMP_CHECKSUM_FILE}}' '{{.CHECKSUM_FILE}}' 2> /dev/null
+        {{- range .DATA_PATHS}}
+        test -e "{{.}}" &&
+        {{- end}}
+        diff -q '{{.TMP_CHECKSUM_FILE}}' '{{.CHECKSUM_FILE}}' 2> /dev/null
         ) || rm -f '{{.CHECKSUM_FILE}}'
 
   # ===
@@ -141,3 +146,159 @@ tasks:
         \( -iname "*.cpp" -o -iname "*.h" -o -iname "*.hpp" \) \
         -print0 | \
           xargs -0 clang-tidy {{.FLAGS}}
+
+  # ===
+  # CMAKE UTILS
+  # ===
+
+  # Runs cmake configure and build steps for the given source and build directories.
+  #
+  # @param {string} BUILD_DIR Cmake build directory to create.
+  # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
+  # @param {string}[optional] CHECKSUM_FILE Path to store the checksum of built files.
+  # @param {string}[optional] CMAKE_ARGS Any additional arguments to pass to cmake configure.
+  cmake-build:
+    label: "cmake-build: {{.SOURCE_DIR}} {{.BUILD_DIR}}"
+    internal: true
+    vars:
+      CHECKSUM_FILE: '{{default (printf "%s.md5" .BUILD_DIR) .CHECKSUM_FILE}}'
+      CMAKE_ARGS: "{{default nil .CMAKE_ARGS}}"
+    requires:
+      vars: ["BUILD_DIR", "SOURCE_DIR"]
+    sources:
+      - "{{.SOURCE_DIR}}/**/*"
+      - exclude: "{{.SOURCE_DIR}}/.cache/**/*"
+      - exclude: "{{.SOURCE_DIR}}/compile_commands.json"
+    generates: ["{{.CHECKSUM_FILE}}"]
+    deps:
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_PATHS: ["{{.BUILD_DIR}}"]
+          EXCLUDE_PATHS: ["install_manifest.txt"]
+    cmds:
+      - >-
+        cmake
+        -S "{{.SOURCE_DIR}}"
+        -B "{{.BUILD_DIR}}"
+        {{.CMAKE_ARGS}}
+      - >-
+        cmake
+        --build "{{.BUILD_DIR}}"
+        --parallel
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_PATHS: ["{{.BUILD_DIR}}"]
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          EXCLUDE_PATHS: ["install_manifest.txt"]
+
+  # Runs cmake install step for the given build directory.
+  #
+  # @param {string} BUILD_DIR Cmake build directory.
+  # @param {string} INSTALL_PREFIX Path prefix for installing the project.
+  # @param {string}[optional] CHECKSUM_FILE Path to store the checksum of installed files.
+  # @param {[]string}[optional] DATA_PATHS Paths to compute the the checksum for. Overrides using
+  # the install prefix path.
+  cmake-install:
+    label: "cmake-install: {{.BUILD_DIR}} {{.INSTALL_PREFIX}}"
+    internal: true
+    vars:
+      CHECKSUM_FILE: '{{default (printf "%s.md5" .INSTALL_PREFIX) .CHECKSUM_FILE}}'
+      # Convert the install prefix to a single element array for the default case where DATA_PATHS
+      # is not manually set.
+      _INSTALL_PREFIX_ARRAY: ["{{.INSTALL_PREFIX}}"]
+      DATA_PATHS:
+        ref: "default ._INSTALL_PREFIX_ARRAY .DATA_PATHS"
+    requires:
+      vars: ["BUILD_DIR", "INSTALL_PREFIX"]
+    sources:
+      - "{{.BUILD_DIR}}/**/*"
+      - exclude: "{{.BUILD_DIR}}/install_manifest.txt"
+    generates: ["{{.CHECKSUM_FILE}}"]
+    deps:
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_PATHS:
+            ref: ".DATA_PATHS"
+    cmds:
+      - >-
+        cmake
+        --install "{{.BUILD_DIR}}"
+        --prefix "{{.INSTALL_PREFIX}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_PATHS:
+            ref: ".DATA_PATHS"
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+
+  # ===
+  # REMOTE UTILS
+  # ===
+
+  # Runs curl to download the provided URL.
+  #
+  # @param {string} URL
+  # @param {string} URL_SHA256 Content hash to verify downloaded file against.
+  # @param {string}[optional] OUTPUT_FILE File path to store the download file.
+  curl:
+    label: "curl: {{.OUTPUT_FILE}}"
+    internal: true
+    vars:
+      OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
+    requires:
+      vars: ["URL", "URL_SHA256"]
+    generates:
+      - "{{.OUTPUT_FILE}}"
+    status:
+      - >-
+        diff
+        <(echo "{{.URL_SHA256}}")
+        <(openssl dgst -sha256 "{{.OUTPUT_FILE}}"
+        | awk '{print $2}')
+    cmds:
+      - |-
+        mkdir -p "{{dir .OUTPUT_FILE}}"
+        curl -L "{{.URL}}" -o "{{.OUTPUT_FILE}}"
+
+  # Runs curl to download the provided URL and tar to extract its contents.
+  #
+  # @param {string} OUTPUT_DIR Path to extract downloaded tar file contents to.
+  # @param {string} URL
+  # @param {string} URL_SHA256 Content hash to verify downloaded tar file against.
+  # @param {string}[optional] CHECKSUM_FILE File path to store the checksum of downloaded tar file.
+  # @param {int}[optional] STRIP Number of leading components to strip from file names for tar.
+  # @param {string}[optional] TAR_FILE File path to store the downloaded tar file.
+  fetch-src:
+    label: "fetch-src: {{.OUTPUT_DIR}}"
+    internal: true
+    vars:
+      CHECKSUM_FILE: '{{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}'
+      STRIP: "{{default 1 .STRIP}}"
+      TAR_FILE: '{{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}'
+    requires:
+      vars: ["OUTPUT_DIR", "URL", "URL_SHA256"]
+    sources: ["{{.TASKFILE}}"]
+    generates: ["{{.CHECKSUM_FILE}}", "{{.TAR_FILE}}"]
+    deps:
+      - task: "curl"
+        vars:
+          URL: "{{.URL}}"
+          URL_SHA256: "{{.URL_SHA256}}"
+          OUTPUT_FILE: "{{.TAR_FILE}}"
+      - task: "validate-checksum"
+        vars:
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
+          DATA_PATHS: ["{{.OUTPUT_DIR}}"]
+    cmds:
+      - |-
+        rm -rf "{{.OUTPUT_DIR}}"
+        mkdir -p "{{.OUTPUT_DIR}}"
+        tar -x --strip-components="{{.STRIP}}" -C "{{.OUTPUT_DIR}}" -f "{{.TAR_FILE}}"
+      # This command must be last
+      - task: "compute-checksum"
+        vars:
+          DATA_PATHS: ["{{.OUTPUT_DIR}}"]
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -20,13 +20,14 @@ tasks:
     requires:
       vars: ["INCLUDE_PATTERNS", "OUTPUT_FILE"]
     cmds:
-      # We explicitly set --no-anchored and --wildcards to ensure the behaviour for both exclusion
-      # and inclusion matches, as they are only the default for exclusion.
-      # We can quote the exclude patterns for tar because the patterns themselves are passed to tar
-      # as arguments and evaluated by tar during execution. However, for tar --create the input
-      # patterns cannot be quoted as they are evaluated by the shell and the results are passed to
-      # tar as arguments. If the input patterns are passed to tar with quotes the pattern will not
-      # be evaluated and will be treated literally.
+      # We explicitly set `--no-anchored` and `--wildcards` to make the inclusion behaviour match
+      # the default exclusion behaviour.
+      #
+      # We can quote the exclude patterns for `tar` because the patterns themselves are passed to
+      # `tar` as arguments and evaluated by `tar` during execution. However, for `tar --create`, the
+      # input patterns cannot be quoted since they're evaluated by the shell and the results are
+      # passed to `tar` as arguments. If the input patterns are passed to `tar` with quotes, the
+      # pattern won't be evaluated and will instead be treated literally.
       - >-
         tar
         --create
@@ -49,10 +50,10 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
+  # @param {string} CHECKSUM_FILE
   # @param {string[]} INCLUDE_PATTERNS Path wildcard patterns to validate the checksum for.
-  # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `INCLUDE_PATTERNS`, to
-  # exclude from the checksum.
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `INCLUDE_PATTERNS`,
+  # to exclude from the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."
@@ -75,7 +76,7 @@ tasks:
       # Check that all paths exist and the checksum matches; otherwise delete the checksum file.
       - |-
         (
-          {{- range .DATA_PATTERNS}}
+          {{- range .INCLUDE_PATTERNS}}
           for path in {{.}}; do
             test -e "$path"
           done
@@ -174,16 +175,16 @@ tasks:
   # @param {string} BUILD_DIR CMake build directory to create.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted the native build tool's default number is used. See man cmake.
+  # omitted, the native build tool's default number is used. See `man cmake`.
   # @param {string} [CONF_ARGS] Any additional arguments to pass to CMake's configure step.
   cmake-config-and-build:
     internal: true
     label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     vars:
-      JOBS: >-
-        {{default "" .JOBS}}
       CONF_ARGS: >-
         {{default "" .CONF_ARGS}}
+      JOBS: >-
+        {{default "" .JOBS}}
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     cmds:
@@ -276,15 +277,20 @@ tasks:
     internal: true
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     vars:
+      # Paths
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
-      INCLUDE_PATTERNS:
-        ref: "default (list) .INCLUDE_PATTERNS"
-      EXCLUDE_PATTERNS:
-        ref: "default (list) .EXCLUDE_PATTERNS"
-      NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
+      
+      # Path patterns
+      EXCLUDE_PATTERNS:
+        ref: "default (list) .EXCLUDE_PATTERNS"
+      INCLUDE_PATTERNS:
+        ref: "default (list) .INCLUDE_PATTERNS"
+      
+      # Misc
+      NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
     requires:
       vars: ["FILE_SHA256", "OUTPUT_DIR", "URL"]
     sources: ["{{.TASKFILE}}", "{{.TAR_FILE}}"]
@@ -303,8 +309,8 @@ tasks:
       - |-
         rm --force --recursive "{{.OUTPUT_DIR}}"
         mkdir --parents  "{{.OUTPUT_DIR}}"
-      # Unlike tar --create, in --extract both the exclude and include patterns can be quoted as
-      # they are both evaluted by tar.
+      # Unlike for `tar --create`, in `--extract` both the exclude and include patterns can be
+      # quoted since they're both evaluated by `tar`.
       - >-
         tar
         --extract

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -56,7 +56,7 @@ tasks:
             ref: ".EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
-      # Check that the directory exists and the checksum matches; otherwise delete the checksum file
+      # Check that the path exists and the checksum matches; otherwise delete the checksum file
       - >-
         (
         {{- range .DATA_PATHS}}

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -53,7 +53,7 @@ tasks:
           DATA_PATHS:
             ref: ".DATA_PATHS"
           EXCLUDE_PATHS:
-            ref: ".EXCLUDE_PATHS"
+            ref: "default (list) .EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the path exists and the checksum matches; otherwise delete the checksum file

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -5,9 +5,9 @@ tasks:
   # CHECKSUM UTILS
   # ===
 
-  # @param {[]string} [DATA_PATHS] List of paths to compute the checksum for.
+  # @param {string[]} DATA_PATHS List of paths to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
+  # @param {string[]} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
   # the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given directory and output it to a file."
@@ -34,9 +34,9 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
-  # @param {[]string} [DATA_PATHS] List of paths to validate the checksum for.
+  # @param {string[]} DATA_PATHS List of paths to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {[]string} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
+  # @param {string[]} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
   # the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
@@ -62,8 +62,8 @@ tasks:
         {{- range .DATA_PATHS}}
         test -e "{{.}}" &&
         {{- end}}
-        diff -q '{{.TMP_CHECKSUM_FILE}}' '{{.CHECKSUM_FILE}}' 2> /dev/null
-        ) || rm -f '{{.CHECKSUM_FILE}}'
+        diff -q "{{.TMP_CHECKSUM_FILE}}" "{{.CHECKSUM_FILE}}" 2> /dev/null
+        ) || rm -f "{{.CHECKSUM_FILE}}"
 
   # ===
   # STRING UTILS
@@ -80,7 +80,7 @@ tasks:
         # 2. We can't use `--regexp` instead of `-E` since `--regexp` is not supported on macOS
         src="{{.FILE_PATH}}"
         dst="{{.FILE_PATH}}.tmp"
-        sed -E '{{.SED_EXP}}' "${src}" > "${dst}"
+        sed -E "{{.SED_EXP}}" "${src}" > "${dst}"
         mv "${dst}" "${src}"
 
   # ===
@@ -116,7 +116,7 @@ tasks:
   # Runs clang-format on C++ files at the given paths.
   #
   # @param {string} FLAGS Any flags to pass to clang-format.
-  # @param {[]string} SRC_PATHS The paths on which to run clang-format.
+  # @param {string[]} SRC_PATHS The paths on which to run clang-format.
   # @param {string} VENV_DIR Python virtual environment where clang-format is installed.
   clang-format:
     internal: true
@@ -133,7 +133,7 @@ tasks:
   # Runs clang-tidy on C++ files at the given paths.
   #
   # @param {string} FLAGS Any flags to pass to clang-tidy.
-  # @param {[]string} SRC_PATHS The paths on which to run clang-tidy.
+  # @param {string[]} SRC_PATHS The paths on which to run clang-tidy.
   # @param {string} VENV_DIR Python virtual environment where clang-tidy is installed.
   clang-tidy:
     internal: true
@@ -155,14 +155,16 @@ tasks:
   #
   # @param {string} BUILD_DIR Cmake build directory to create.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
-  # @param {string}[optional] CHECKSUM_FILE Path to store the checksum of built files.
-  # @param {string}[optional] CMAKE_ARGS Any additional arguments to pass to cmake configure.
+  # @param {string={{.BUILD_DIR}}.md5} [CHECKSUM_FILE] Path to store the checksum of built files.
+  # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to cmake configure.
   cmake-build:
-    label: "cmake-build: {{.SOURCE_DIR}} {{.BUILD_DIR}}"
+    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     internal: true
     vars:
-      CHECKSUM_FILE: '{{default (printf "%s.md5" .BUILD_DIR) .CHECKSUM_FILE}}'
-      CMAKE_ARGS: "{{default "" .CMAKE_ARGS}}"
+      CHECKSUM_FILE: >-
+        {{default (printf "%s.md5" .BUILD_DIR) .CHECKSUM_FILE}}
+      CMAKE_ARGS: >-
+        {{default "" .CMAKE_ARGS}}
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     sources:
@@ -197,16 +199,17 @@ tasks:
   #
   # @param {string} BUILD_DIR Cmake build directory.
   # @param {string} INSTALL_PREFIX Path prefix for installing the project.
-  # @param {string}[optional] CHECKSUM_FILE Path to store the checksum of installed files.
-  # @param {[]string}[optional] DATA_PATHS Paths to compute the the checksum for. Overrides using
-  # the install prefix path.
+  # @param {string={{.INSTALL_PREFIX}}.md5} [CHECKSUM_FILE] Path to store the checksum of installed
+  # files.
+  # @param {string[]=[{{.INSTALL_PREFIX}}]} [DATA_PATHS] Paths to compute the the checksum for.
   cmake-install:
-    label: "cmake-install: {{.BUILD_DIR}} {{.INSTALL_PREFIX}}"
+    label: "{{.TASK}}-{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}"
     internal: true
     vars:
-      CHECKSUM_FILE: '{{default (printf "%s.md5" .INSTALL_PREFIX) .CHECKSUM_FILE}}'
-      # Convert the install prefix to a single element array for the default case where DATA_PATHS
-      # is not manually set.
+      CHECKSUM_FILE: >-
+        {{default (printf "%s.md5" .INSTALL_PREFIX) .CHECKSUM_FILE}}
+      # Convert the install prefix to a single element array in the default case where DATA_PATHS
+      # has not been set.
       _INSTALL_PREFIX_ARRAY: ["{{.INSTALL_PREFIX}}"]
       DATA_PATHS:
         ref: "default ._INSTALL_PREFIX_ARRAY .DATA_PATHS"
@@ -242,9 +245,9 @@ tasks:
   #
   # @param {string} URL
   # @param {string} URL_SHA256 Content hash to verify downloaded file against.
-  # @param {string}[optional] OUTPUT_FILE File path to store the download file.
+  # @param {string={{(base .URL)}}} [OUTPUT_FILE] File path to store the download file.
   curl:
-    label: "curl: {{.OUTPUT_FILE}}"
+    label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     internal: true
     vars:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
@@ -261,23 +264,41 @@ tasks:
     cmds:
       - |-
         mkdir -p "{{dir .OUTPUT_FILE}}"
-        curl -L "{{.URL}}" -o "{{.OUTPUT_FILE}}"
+        max_attempts=3
+        attempt=1
+        while [ $attempt -le $max_attempts ]; do
+          if curl --fail --location --show-error --connect-timeout 10 --max-time 300 \
+              --location "{{.URL}}" --output "{{.OUTPUT_FILE}}";
+          then
+            break
+          fi
+          echo "Attempt $attempt failed. Retrying..."
+          attempt=$((attempt + 1))
+          sleep 5
+        done
+        if [ $attempt -gt $max_attempts ]; then
+          echo "Failed to download after $max_attempts attempts"
+          exit 1
+        fi
 
   # Runs curl to download the provided URL and tar to extract its contents.
   #
   # @param {string} OUTPUT_DIR Path to extract downloaded tar file contents to.
   # @param {string} URL
   # @param {string} URL_SHA256 Content hash to verify downloaded tar file against.
-  # @param {string}[optional] CHECKSUM_FILE File path to store the checksum of downloaded tar file.
-  # @param {int}[optional] STRIP Number of leading components to strip from file names for tar.
-  # @param {string}[optional] TAR_FILE File path to store the downloaded tar file.
-  fetch-src:
-    label: "fetch-src: {{.OUTPUT_DIR}}"
+  # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
+  # downloaded tar file.
+  # @param {int=1} [STRIP] Number of leading components to strip from file names for tar.
+  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] File path to store the downloaded tar file.
+  download-and-extract-tar:
+    label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     internal: true
     vars:
-      CHECKSUM_FILE: '{{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}'
+      CHECKSUM_FILE: >-
+        {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
       STRIP: "{{default 1 .STRIP}}"
-      TAR_FILE: '{{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}'
+      TAR_FILE: >-
+        {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
     requires:
       vars: ["OUTPUT_DIR", "URL", "URL_SHA256"]
     sources: ["{{.TASKFILE}}"]

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -1,5 +1,8 @@
 version: "3"
 
+set: ["u", "pipefail"]
+shopt: ["globstar"]
+
 tasks:
   # ===
   # CHECKSUM UTILS
@@ -29,7 +32,7 @@ tasks:
         --exclude="{{.}}"
         {{- end}}
         {{- range .DATA_PATTERNS}}
-        "{{.}}"
+        {{.}}
         {{- end}}
         2> /dev/null
         | md5sum > {{.OUTPUT_FILE}}
@@ -58,13 +61,14 @@ tasks:
             ref: "default (list) .EXCLUDE_PATTERNS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
-      # Check that the paths exist and the checksum matches; otherwise delete the checksum file.
-      - >-
-        (
-        {{- range .DATA_PATTERNS}}
-        test -e "{{.}}" &&
-        {{- end}}
-        diff -q "{{.TMP_CHECKSUM_FILE}}" "{{.CHECKSUM_FILE}}" 2> /dev/null
+      # Check that all paths exist and the checksum matches; otherwise delete the checksum file.
+      - |-
+        ( {{- range .DATA_PATTERNS}}
+          for path in {{.}}; do
+            test -e "$path"
+          done
+          {{- end}}
+          diff -q "{{.TMP_CHECKSUM_FILE}}" "{{.CHECKSUM_FILE}}" 2> /dev/null
         ) || rm -f "{{.CHECKSUM_FILE}}"
 
   # ===

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -177,7 +177,7 @@ tasks:
         --build "{{.BUILD_DIR}}"
         --parallel
 
-  # Unconditionally runs the CMake install step for the given build directory.
+  # Runs the CMake install step for the given build directory.
   #
   # @param {string} BUILD_DIR CMake build directory.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
@@ -199,7 +199,7 @@ tasks:
   # Runs curl to download a file from the given URL.
   #
   # @param {string} URL
-  # @param {string} FILE_SHA256 Content hash to verify downloaded file against.
+  # @param {string} FILE_SHA256 Content hash to verify the downloaded file against.
   # @param {string={{(base .URL)}}} [OUTPUT_FILE] Path where the file should be stored.
   curl:
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
@@ -240,18 +240,18 @@ tasks:
           exit 1
         fi
 
-  # Runs curl to download the tarball file from the given URL and extracts its contents.
+  # Runs curl to download the tar file from the given URL and extracts its contents.
   #
-  # @param {string} OUTPUT_DIR Directory in which to extract the tarball file.
+  # @param {string} OUTPUT_DIR Directory in which to extract the tar file.
   # @param {string} URL
-  # @param {string} FILE_SHA256 Content hash to verify downloaded tar file against.
+  # @param {string} FILE_SHA256 Content hash to verify the downloaded tar file against.
   # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
   # downloaded tar file.
   # @param {string[]=[]} [EXCLUDE_PATTERNS] Path wildcard patterns that should not be extracted.
   # @param {string[]=[]} [DATA_PATTERNS] Path wildcard patterns to extract.
   # @param {int=1} [NUM_COMPONENTS_TO_STRIP] Number of leading path components to strip from the
   # extracted files.
-  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tarball file should be stored.
+  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tar file should be stored.
   download-and-extract-tar:
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     internal: true

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -5,17 +5,16 @@ tasks:
   # CHECKSUM UTILS
   # ===
 
-  # @param {string[]} DATA_PATHS List of paths to compute the checksum for.
+  # @param {string[]} DATA_PATTERNS Path wildcard patterns to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATHS`, to
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATTERNS`, to
   # exclude from the checksum.
-  # the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given paths and output it to a file."
     internal: true
     silent: true
     requires:
-      vars: ["DATA_PATHS", "OUTPUT_FILE"]
+      vars: ["DATA_PATTERNS", "OUTPUT_FILE"]
     cmds:
       - >-
         tar cf -
@@ -29,7 +28,7 @@ tasks:
         {{- range .EXCLUDE_PATTERNS}}
         --exclude="{{.}}"
         {{- end}}
-        {{- range .DATA_PATHS}}
+        {{- range .DATA_PATTERNS}}
         "{{.}}"
         {{- end}}
         2> /dev/null
@@ -37,10 +36,10 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
-  # @param {string[]} DATA_PATHS List of paths to validate the checksum for.
+  # @param {string[]} DATA_PATTERNS Path wildcard patterns to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATTERNS] List of paths, relative to any `DATA_PATHS`, to exclude
-  # from the checksum.
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATTERNS`, to
+  # exclude from the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."
@@ -49,12 +48,12 @@ tasks:
     vars:
       TMP_CHECKSUM_FILE: "{{.CHECKSUM_FILE}}.tmp"
     requires:
-      vars: ["CHECKSUM_FILE", "DATA_PATHS"]
+      vars: ["CHECKSUM_FILE", "DATA_PATTERNS"]
     cmds:
       - task: "compute-checksum"
         vars:
-          DATA_PATHS:
-            ref: ".DATA_PATHS"
+          DATA_PATTERNS:
+            ref: ".DATA_PATTERNS"
           EXCLUDE_PATTERNS:
             ref: "default (list) .EXCLUDE_PATTERNS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
@@ -62,7 +61,7 @@ tasks:
       # Check that the paths exist and the checksum matches; otherwise delete the checksum file.
       - >-
         (
-        {{- range .DATA_PATHS}}
+        {{- range .DATA_PATTERNS}}
         test -e "{{.}}" &&
         {{- end}}
         diff -q "{{.TMP_CHECKSUM_FILE}}" "{{.CHECKSUM_FILE}}" 2> /dev/null
@@ -158,27 +157,15 @@ tasks:
   #
   # @param {string} BUILD_DIR CMake build directory to create.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
-  # @param {string={{.BUILD_DIR}}.md5} [CHECKSUM_FILE] Path to store the checksum of built files.
   # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to CMake's configure step.
   cmake-config-and-build:
     label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     internal: true
     vars:
-      CHECKSUM_FILE: >-
-        {{default (printf "%s.md5" .BUILD_DIR) .CHECKSUM_FILE}}
       CMAKE_ARGS: >-
         {{default "" .CMAKE_ARGS}}
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
-    sources:
-      - "{{.SOURCE_DIR}}/**/*"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - task: "validate-checksum"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_PATHS: ["{{.BUILD_DIR}}"]
-          EXCLUDE_PATTERNS: ["install_manifest.txt"]
     cmds:
       - >-
         cmake
@@ -189,51 +176,21 @@ tasks:
         cmake
         --build "{{.BUILD_DIR}}"
         --parallel
-      # This command must be last
-      - task: "compute-checksum"
-        vars:
-          DATA_PATHS: ["{{.BUILD_DIR}}"]
-          EXCLUDE_PATHS: ["install_manifest.txt"]
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
-  # Runs the CMake install step for the given build directory.
+  # Unconditionally runs the CMake install step for the given build directory.
   #
   # @param {string} BUILD_DIR CMake build directory.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
-  # @param {string={{.INSTALL_PREFIX}}.md5} [CHECKSUM_FILE] Path to store the checksum of installed
-  # files.
-  # @param {string[]=[{{.INSTALL_PREFIX}}]} [DATA_PATHS] Paths to compute the the checksum for.
   cmake-install:
     label: "{{.TASK}}-{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}"
     internal: true
-    vars:
-      CHECKSUM_FILE: >-
-        {{default (printf "%s.md5" .INSTALL_PREFIX) .CHECKSUM_FILE}}
-      DATA_PATHS:
-        ref: "default (list .INSTALL_PREFIX) .DATA_PATHS"
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
-    sources:
-      - "{{.BUILD_DIR}}/**/*"
-      - exclude: "{{.BUILD_DIR}}/install_manifest.txt"
-    generates: ["{{.CHECKSUM_FILE}}"]
-    deps:
-      - task: "validate-checksum"
-        vars:
-          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_PATHS:
-            ref: ".DATA_PATHS"
     cmds:
       - >-
         cmake
         --install "{{.BUILD_DIR}}"
         --prefix "{{.INSTALL_PREFIX}}"
-      # This command must be last
-      - task: "compute-checksum"
-        vars:
-          DATA_PATHS:
-            ref: ".DATA_PATHS"
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
   # ===
   # REMOTE UTILS
@@ -275,7 +232,6 @@ tasks:
           then
             break
           fi
-          echo "Attempt $attempt failed. Retrying..."
           attempt=$((attempt + 1))
           sleep 5
         done
@@ -284,18 +240,18 @@ tasks:
           exit 1
         fi
 
-  # Runs curl to download the tarball from the given URL and extracts its contents.
+  # Runs curl to download the tarball file from the given URL and extracts its contents.
   #
-  # @param {string} OUTPUT_DIR Directory in which to extract the tarball.
+  # @param {string} OUTPUT_DIR Directory in which to extract the tarball file.
   # @param {string} URL
   # @param {string} FILE_SHA256 Content hash to verify downloaded tar file against.
   # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
   # downloaded tar file.
-  # @param {string[]=[]} [EXCLUDE_PATHS] Wildcard patterns for paths that shouldn't be extracted.
-  # @param {string[]=[]} [INCLUDE_PATHS] Wildcard patterns for paths to extract.
+  # @param {string[]=[]} [EXCLUDE_PATTERNS] Path wildcard patterns that should not be extracted.
+  # @param {string[]=[]} [DATA_PATTERNS] Path wildcard patterns to extract.
   # @param {int=1} [NUM_COMPONENTS_TO_STRIP] Number of leading path components to strip from the
   # extracted files.
-  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tarball should be stored.
+  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tarball file should be stored.
   download-and-extract-tar:
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     internal: true
@@ -304,8 +260,8 @@ tasks:
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
       EXCLUDE_PATTERNS:
         ref: "default (list) .EXCLUDE_PATTERNS"
-      INCLUDE_PATHS:
-        ref: "default (list) .INCLUDE_PATHS"
+      DATA_PATTERNS:
+        ref: "default (list) .DATA_PATTERNS"
       NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
@@ -322,7 +278,7 @@ tasks:
       - task: "validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_PATHS: ["{{.OUTPUT_DIR}}"]
+          DATA_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - |-
         rm -rf "{{.OUTPUT_DIR}}"
@@ -338,12 +294,12 @@ tasks:
         {{- range .EXCLUDE_PATTERNS}}
         --exclude="{{.}}"
         {{- end}}
-        {{- range .DATA_PATHS}}
+        {{- range .DATA_PATTERNS}}
         "{{.}}"
         {{- end}}
         2> /dev/null
       # This command must be last
       - task: "compute-checksum"
         vars:
-          DATA_PATHS: ["{{.OUTPUT_DIR}}"]
+          DATA_PATTERNS: ["{{.OUTPUT_DIR}}"]
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -14,7 +14,7 @@ tasks:
     internal: true
     silent: true
     requires:
-      vars: ["DATA_DIR", "OUTPUT_FILE"]
+      vars: ["DATA_PATHS", "OUTPUT_FILE"]
     cmds:
       - >-
         tar cf -
@@ -46,7 +46,7 @@ tasks:
     vars:
       TMP_CHECKSUM_FILE: "{{.CHECKSUM_FILE}}.tmp"
     requires:
-      vars: ["CHECKSUM_FILE", "DATA_DIR"]
+      vars: ["CHECKSUM_FILE", "DATA_PATHS"]
     cmds:
       - task: "compute-checksum"
         vars:
@@ -162,7 +162,7 @@ tasks:
     internal: true
     vars:
       CHECKSUM_FILE: '{{default (printf "%s.md5" .BUILD_DIR) .CHECKSUM_FILE}}'
-      CMAKE_ARGS: "{{default nil .CMAKE_ARGS}}"
+      CMAKE_ARGS: "{{default "" .CMAKE_ARGS}}"
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     sources:

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -15,6 +15,7 @@ tasks:
   compute-checksum:
     desc: "Tries to compute a checksum for the given paths and output it to a file."
     internal: true
+    label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     silent: true
     requires:
       vars: ["DATA_PATTERNS", "OUTPUT_FILE"]
@@ -47,6 +48,7 @@ tasks:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."
     internal: true
+    label: "{{.TASK}}-{{.CHECKSUM_FILE}}"
     silent: true
     vars:
       TMP_CHECKSUM_FILE: "{{.CHECKSUM_FILE}}.tmp"
@@ -163,8 +165,8 @@ tasks:
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
   # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to CMake's configure step.
   cmake-config-and-build:
-    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     internal: true
+    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     vars:
       CMAKE_ARGS: >-
         {{default "" .CMAKE_ARGS}}
@@ -186,8 +188,8 @@ tasks:
   # @param {string} BUILD_DIR CMake build directory.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   cmake-install:
-    label: "{{.TASK}}-{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}"
     internal: true
+    label: "{{.TASK}}-{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}"
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     cmds:
@@ -206,8 +208,8 @@ tasks:
   # @param {string} FILE_SHA256 Content hash to verify the downloaded file against.
   # @param {string={{(base .URL)}}} [OUTPUT_FILE] Path where the file should be stored.
   curl:
-    label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     internal: true
+    label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     vars:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
     requires:
@@ -257,8 +259,8 @@ tasks:
   # extracted files.
   # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tar file should be stored.
   download-and-extract-tar:
-    label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     internal: true
+    label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -8,20 +8,29 @@ tasks:
   # CHECKSUM UTILS
   # ===
 
-  # @param {string[]} DATA_PATTERNS Path wildcard patterns to compute the checksum for.
+  # @param {string[]} INCLUDE_PATTERNS Path wildcard patterns to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATTERNS`, to
-  # exclude from the checksum.
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `INCLUDE_PATTERNS`,
+  # to exclude from the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given paths and output it to a file."
     internal: true
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     silent: true
     requires:
-      vars: ["DATA_PATTERNS", "OUTPUT_FILE"]
+      vars: ["INCLUDE_PATTERNS", "OUTPUT_FILE"]
     cmds:
+      # We explicitly set --no-anchored and --wildcards to ensure the behaviour for both exclusion
+      # and inclusion matches, as they are only the default for exclusion.
+      # We can quote the exclude patterns for tar because the patterns themselves are passed to tar
+      # as arguments and evaluated by tar during execution. However, for tar --create the input
+      # patterns cannot be quoted as they are evaluated by the shell and the results are passed to
+      # tar as arguments. If the input patterns are passed to tar with quotes the pattern will not
+      # be evaluated and will be treated literally.
       - >-
-        tar cf -
+        tar
+        --create
+        --file -
         --group 0
         --mtime "UTC 1970-01-01"
         --numeric-owner
@@ -32,7 +41,7 @@ tasks:
         {{- range .EXCLUDE_PATTERNS}}
         --exclude="{{.}}"
         {{- end}}
-        {{- range .DATA_PATTERNS}}
+        {{- range .INCLUDE_PATTERNS}}
         {{.}}
         {{- end}}
         2> /dev/null
@@ -40,9 +49,9 @@ tasks:
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
-  # @param {string[]} DATA_PATTERNS Path wildcard patterns to validate the checksum for.
+  # @param {string[]} INCLUDE_PATTERNS Path wildcard patterns to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATTERNS`, to
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `INCLUDE_PATTERNS`, to
   # exclude from the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
@@ -53,12 +62,12 @@ tasks:
     vars:
       TMP_CHECKSUM_FILE: "{{.CHECKSUM_FILE}}.tmp"
     requires:
-      vars: ["CHECKSUM_FILE", "DATA_PATTERNS"]
+      vars: ["CHECKSUM_FILE", "INCLUDE_PATTERNS"]
     cmds:
       - task: "compute-checksum"
         vars:
-          DATA_PATTERNS:
-            ref: ".DATA_PATTERNS"
+          INCLUDE_PATTERNS:
+            ref: ".INCLUDE_PATTERNS"
           EXCLUDE_PATTERNS:
             ref: "default (list) .EXCLUDE_PATTERNS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
@@ -164,13 +173,17 @@ tasks:
   #
   # @param {string} BUILD_DIR CMake build directory to create.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
-  # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to CMake's configure step.
+  # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
+  # omitted the native build tool's default number is used. See man cmake.
+  # @param {string} [CONF_ARGS] Any additional arguments to pass to CMake's configure step.
   cmake-config-and-build:
     internal: true
     label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     vars:
-      CMAKE_ARGS: >-
-        {{default "" .CMAKE_ARGS}}
+      JOBS: >-
+        {{default "" .JOBS}}
+      CONF_ARGS: >-
+        {{default "" .CONF_ARGS}}
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     cmds:
@@ -178,11 +191,11 @@ tasks:
         cmake
         -S "{{.SOURCE_DIR}}"
         -B "{{.BUILD_DIR}}"
-        {{.CMAKE_ARGS}}
+        {{.CONF_ARGS}}
       - >-
         cmake
         --build "{{.BUILD_DIR}}"
-        --parallel
+        --parallel "{{.JOBS}}"
 
   # Runs the CMake install step for the given build directory.
   #
@@ -207,7 +220,7 @@ tasks:
   #
   # @param {string} URL
   # @param {string} FILE_SHA256 Content hash to verify the downloaded file against.
-  # @param {string={{(base .URL)}}} [OUTPUT_FILE] Path where the file should be stored.
+  # @param {string} [OUTPUT_FILE={{(base .URL)}}] Path where the file should be stored.
   curl:
     internal: true
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
@@ -224,7 +237,7 @@ tasks:
         | awk '{print $2}')
     cmds:
       - |-
-        mkdir -p "{{dir .OUTPUT_FILE}}"
+        mkdir --parents "{{dir .OUTPUT_FILE}}"
         max_attempts=3
         attempt=1
         while [ $attempt -le $max_attempts ]; do
@@ -252,21 +265,21 @@ tasks:
   # @param {string} OUTPUT_DIR Directory in which to extract the tar file.
   # @param {string} URL
   # @param {string} FILE_SHA256 Content hash to verify the downloaded tar file against.
-  # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of the
+  # @param {string} [CHECKSUM_FILE={{.OUTPUT_DIR}}.md5] File path to store the checksum of the
   # downloaded tar file.
-  # @param {string[]=[]} [EXCLUDE_PATTERNS] Path wildcard patterns that should not be extracted.
-  # @param {string[]=[]} [DATA_PATTERNS] Path wildcard patterns to extract.
-  # @param {int=1} [NUM_COMPONENTS_TO_STRIP] Number of leading path components to strip from the
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns that should not be extracted.
+  # @param {string[]} [INCLUDE_PATTERNS] Path wildcard patterns to extract.
+  # @param {int} [NUM_COMPONENTS_TO_STRIP=1] Number of leading path components to strip from the
   # extracted files.
-  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tar file should be stored.
+  # @param {string} [TAR_FILE={{.OUTPUT_DIR}}.tar.gz] Path where the tar file should be stored.
   download-and-extract-tar:
     internal: true
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
-      DATA_PATTERNS:
-        ref: "default (list) .DATA_PATTERNS"
+      INCLUDE_PATTERNS:
+        ref: "default (list) .INCLUDE_PATTERNS"
       EXCLUDE_PATTERNS:
         ref: "default (list) .EXCLUDE_PATTERNS"
       NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
@@ -274,8 +287,8 @@ tasks:
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
     requires:
       vars: ["FILE_SHA256", "OUTPUT_DIR", "URL"]
-    sources: ["{{.TASKFILE}}"]
-    generates: ["{{.CHECKSUM_FILE}}", "{{.TAR_FILE}}"]
+    sources: ["{{.TASKFILE}}", "{{.TAR_FILE}}"]
+    generates: ["{{.CHECKSUM_FILE}}"]
     deps:
       - task: "curl"
         vars:
@@ -285,11 +298,13 @@ tasks:
       - task: "validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
-          DATA_PATTERNS: ["{{.OUTPUT_DIR}}"]
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
     cmds:
       - |-
-        rm -rf "{{.OUTPUT_DIR}}"
-        mkdir -p "{{.OUTPUT_DIR}}"
+        rm --force --recursive "{{.OUTPUT_DIR}}"
+        mkdir --parents  "{{.OUTPUT_DIR}}"
+      # Unlike tar --create, in --extract both the exclude and include patterns can be quoted as
+      # they are both evaluted by tar.
       - >-
         tar
         --extract
@@ -301,12 +316,12 @@ tasks:
         {{- range .EXCLUDE_PATTERNS}}
         --exclude="{{.}}"
         {{- end}}
-        {{- range .DATA_PATTERNS}}
+        {{- range .INCLUDE_PATTERNS}}
         "{{.}}"
         {{- end}}
         2> /dev/null
       # This command must be last
       - task: "compute-checksum"
         vars:
-          DATA_PATTERNS: ["{{.OUTPUT_DIR}}"]
+          INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
           OUTPUT_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -8,17 +8,17 @@ tasks:
   # CHECKSUM UTILS
   # ===
 
+  # @param {string} CHECKSUM_FILE
   # @param {string[]} INCLUDE_PATTERNS Path wildcard patterns to compute the checksum for.
-  # @param {string} OUTPUT_FILE
   # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `INCLUDE_PATTERNS`,
   # to exclude from the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given paths and output it to a file."
     internal: true
-    label: "{{.TASK}}-{{.OUTPUT_FILE}}"
+    label: "{{.TASK}}-{{.CHECKSUM_FILE}}"
     silent: true
     requires:
-      vars: ["INCLUDE_PATTERNS", "OUTPUT_FILE"]
+      vars: ["CHECKSUM_FILE", "INCLUDE_PATTERNS"]
     cmds:
       # We explicitly set `--no-anchored` and `--wildcards` to make the inclusion behaviour match
       # the default exclusion behaviour.
@@ -46,7 +46,7 @@ tasks:
         {{.}}
         {{- end}}
         2> /dev/null
-        | md5sum > {{.OUTPUT_FILE}}
+        | md5sum > {{.CHECKSUM_FILE}}
     # Ignore errors so that dependent tasks don't fail
     ignore_error: true
 
@@ -71,7 +71,7 @@ tasks:
             ref: ".INCLUDE_PATTERNS"
           EXCLUDE_PATTERNS:
             ref: "default (list) .EXCLUDE_PATTERNS"
-          OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that all paths exist and the checksum matches; otherwise delete the checksum file.
       - |-
@@ -282,13 +282,13 @@ tasks:
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
-      
+
       # Path patterns
       EXCLUDE_PATTERNS:
         ref: "default (list) .EXCLUDE_PATTERNS"
       INCLUDE_PATTERNS:
         ref: "default (list) .INCLUDE_PATTERNS"
-      
+
       # Misc
       NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
     requires:
@@ -330,4 +330,4 @@ tasks:
       - task: "compute-checksum"
         vars:
           INCLUDE_PATTERNS: ["{{.OUTPUT_DIR}}"]
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
+          CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -207,7 +207,7 @@ tasks:
     vars:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
     requires:
-      vars: ["URL", "FILE_SHA256"]
+      vars: ["FILE_SHA256", "URL"]
     generates: ["{{.OUTPUT_FILE}}"]
     status:
       - >-
@@ -258,23 +258,23 @@ tasks:
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
-      EXCLUDE_PATTERNS:
-        ref: "default (list) .EXCLUDE_PATTERNS"
       DATA_PATTERNS:
         ref: "default (list) .DATA_PATTERNS"
+      EXCLUDE_PATTERNS:
+        ref: "default (list) .EXCLUDE_PATTERNS"
       NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
     requires:
-      vars: ["OUTPUT_DIR", "URL", "FILE_SHA256"]
+      vars: ["FILE_SHA256", "OUTPUT_DIR", "URL"]
     sources: ["{{.TASKFILE}}"]
     generates: ["{{.CHECKSUM_FILE}}", "{{.TAR_FILE}}"]
     deps:
       - task: "curl"
         vars:
-          URL: "{{.URL}}"
           FILE_SHA256: "{{.FILE_SHA256}}"
           OUTPUT_FILE: "{{.TAR_FILE}}"
+          URL: "{{.URL}}"
       - task: "validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -56,7 +56,7 @@ tasks:
             ref: "default (list) .EXCLUDE_PATHS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
-      # Check that the path exists and the checksum matches; otherwise delete the checksum file
+      # Check that the paths exist and the checksum matches; otherwise delete the checksum file.
       - >-
         (
         {{- range .DATA_PATHS}}
@@ -151,12 +151,12 @@ tasks:
   # CMAKE UTILS
   # ===
 
-  # Runs cmake configure and build steps for the given source and build directories.
+  # Runs CMake's configure and build steps for the given source and build directories.
   #
-  # @param {string} BUILD_DIR Cmake build directory to create.
+  # @param {string} BUILD_DIR CMake build directory to create.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
   # @param {string={{.BUILD_DIR}}.md5} [CHECKSUM_FILE] Path to store the checksum of built files.
-  # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to cmake configure.
+  # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to CMake's configure step.
   cmake-build:
     label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     internal: true
@@ -192,13 +192,13 @@ tasks:
       - task: "compute-checksum"
         vars:
           DATA_PATHS: ["{{.BUILD_DIR}}"]
-          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
           EXCLUDE_PATHS: ["install_manifest.txt"]
+          OUTPUT_FILE: "{{.CHECKSUM_FILE}}"
 
-  # Runs cmake install step for the given build directory.
+  # Runs the CMake install step for the given build directory.
   #
-  # @param {string} BUILD_DIR Cmake build directory.
-  # @param {string} INSTALL_PREFIX Path prefix for installing the project.
+  # @param {string} BUILD_DIR CMake build directory.
+  # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string={{.INSTALL_PREFIX}}.md5} [CHECKSUM_FILE] Path to store the checksum of installed
   # files.
   # @param {string[]=[{{.INSTALL_PREFIX}}]} [DATA_PATHS] Paths to compute the the checksum for.
@@ -208,11 +208,8 @@ tasks:
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .INSTALL_PREFIX) .CHECKSUM_FILE}}
-      # Convert the install prefix to a single element array in the default case where DATA_PATHS
-      # has not been set.
-      _INSTALL_PREFIX_ARRAY: ["{{.INSTALL_PREFIX}}"]
       DATA_PATHS:
-        ref: "default ._INSTALL_PREFIX_ARRAY .DATA_PATHS"
+        ref: "default (list .INSTALL_PREFIX) .DATA_PATHS"
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     sources:
@@ -241,11 +238,11 @@ tasks:
   # REMOTE UTILS
   # ===
 
-  # Runs curl to download the provided URL.
+  # Runs curl to download a file from the given URL.
   #
   # @param {string} URL
   # @param {string} URL_SHA256 Content hash to verify downloaded file against.
-  # @param {string={{(base .URL)}}} [OUTPUT_FILE] File path to store the download file.
+  # @param {string={{(base .URL)}}} [OUTPUT_FILE] Path where the file should be stored.
   curl:
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     internal: true
@@ -253,8 +250,7 @@ tasks:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
     requires:
       vars: ["URL", "URL_SHA256"]
-    generates:
-      - "{{.OUTPUT_FILE}}"
+    generates: ["{{.OUTPUT_FILE}}"]
     status:
       - >-
         diff
@@ -277,21 +273,21 @@ tasks:
           sleep 5
         done
         if [ $attempt -gt $max_attempts ]; then
-          echo "Failed to download after $max_attempts attempts"
+          echo "Failed to download after $max_attempts attempts."
           exit 1
         fi
 
-  # Runs curl to download the provided URL and tar to extract its contents.
+  # Runs curl to download the tarball from the given URL and extracts its contents.
   #
-  # @param {string} OUTPUT_DIR Path to extract downloaded tar file contents to.
+  # @param {string} OUTPUT_DIR Directory in which to extract the tarball.
   # @param {string} URL
   # @param {string} URL_SHA256 Content hash to verify downloaded tar file against.
   # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
   # downloaded tar file.
-  # @param {string[]=[]} [EXCLUDE_PATHS] Wildcard patterns excluded from the tar archive.
-  # @param {string[]=[]} [INCLUDE_PATHS] Wildcard patterns included from the tar archive.
-  # @param {int=1} [STRIP] Number of leading components to strip from file names for tar.
-  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] File path to store the downloaded tar file.
+  # @param {string[]=[]} [EXCLUDE_PATHS] Wildcard patterns for paths that shouldn't be extracted.
+  # @param {string[]=[]} [INCLUDE_PATHS] Wildcard patterns for paths to extract.
+  # @param {int=1} [STRIP] Number of leading path components to strip from the extracted files.
+  # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tarball should be stored.
   download-and-extract-tar:
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
     internal: true

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -65,7 +65,8 @@ tasks:
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that all paths exist and the checksum matches; otherwise delete the checksum file.
       - |-
-        ( {{- range .DATA_PATTERNS}}
+        (
+          {{- range .DATA_PATTERNS}}
           for path in {{.}}; do
             test -e "$path"
           done
@@ -251,7 +252,7 @@ tasks:
   # @param {string} OUTPUT_DIR Directory in which to extract the tar file.
   # @param {string} URL
   # @param {string} FILE_SHA256 Content hash to verify the downloaded tar file against.
-  # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
+  # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of the
   # downloaded tar file.
   # @param {string[]=[]} [EXCLUDE_PATTERNS] Path wildcard patterns that should not be extracted.
   # @param {string[]=[]} [DATA_PATTERNS] Path wildcard patterns to extract.

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -10,7 +10,7 @@ tasks:
   # @param {string[]} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
   # the checksum.
   compute-checksum:
-    desc: "Tries to compute a checksum for the given directory and output it to a file."
+    desc: "Tries to compute a checksum for the given paths and output it to a file."
     internal: true
     silent: true
     requires:
@@ -288,6 +288,8 @@ tasks:
   # @param {string} URL_SHA256 Content hash to verify downloaded tar file against.
   # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
   # downloaded tar file.
+  # @param {string[]=[]} [EXCLUDE_PATHS] Wildcard patterns excluded from the tar archive.
+  # @param {string[]=[]} [INCLUDE_PATHS] Wildcard patterns included from the tar archive.
   # @param {int=1} [STRIP] Number of leading components to strip from file names for tar.
   # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] File path to store the downloaded tar file.
   download-and-extract-tar:
@@ -296,6 +298,10 @@ tasks:
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
+      EXCLUDE_PATHS:
+        ref: "default (list) .EXCLUDE_PATHS"
+      INCLUDE_PATHS:
+        ref: "default (list) .INCLUDE_PATHS"
       STRIP: "{{default 1 .STRIP}}"
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
@@ -317,7 +323,15 @@ tasks:
       - |-
         rm -rf "{{.OUTPUT_DIR}}"
         mkdir -p "{{.OUTPUT_DIR}}"
-        tar -x --strip-components="{{.STRIP}}" -C "{{.OUTPUT_DIR}}" -f "{{.TAR_FILE}}"
+      - >-
+        tar --extract
+        --strip-components="{{.STRIP}}"
+        --directory "{{.OUTPUT_DIR}}"
+        --file "{{.TAR_FILE}}"
+        --wildcards
+        --no-anchored
+        {{- range .INCLUDE_PATHS}} "{{.}}" {{- end}}
+        {{- range .EXCLUDE_PATHS}} --exclude="{{.}}" {{- end}}
       # This command must be last
       - task: "compute-checksum"
         vars:

--- a/taskfiles/utils.yml
+++ b/taskfiles/utils.yml
@@ -7,7 +7,8 @@ tasks:
 
   # @param {string[]} DATA_PATHS List of paths to compute the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
+  # @param {string[]} [EXCLUDE_PATTERNS] Path wildcard patterns, relative to any `DATA_PATHS`, to
+  # exclude from the checksum.
   # the checksum.
   compute-checksum:
     desc: "Tries to compute a checksum for the given paths and output it to a file."
@@ -23,7 +24,9 @@ tasks:
         --numeric-owner
         --owner 0
         --sort name
-        {{- range .EXCLUDE_PATHS}}
+        --no-anchored
+        --wildcards
+        {{- range .EXCLUDE_PATTERNS}}
         --exclude="{{.}}"
         {{- end}}
         {{- range .DATA_PATHS}}
@@ -36,8 +39,8 @@ tasks:
 
   # @param {string[]} DATA_PATHS List of paths to validate the checksum for.
   # @param {string} OUTPUT_FILE
-  # @param {string[]} [EXCLUDE_PATHS] List of paths, relative to any `DATA_PATHS`, to exclude from
-  # the checksum.
+  # @param {string[]} [EXCLUDE_PATTERNS] List of paths, relative to any `DATA_PATHS`, to exclude
+  # from the checksum.
   validate-checksum:
     desc: "Validates the checksum of the given directory matches the checksum in the given file, or
     deletes the checksum file otherwise."
@@ -52,8 +55,8 @@ tasks:
         vars:
           DATA_PATHS:
             ref: ".DATA_PATHS"
-          EXCLUDE_PATHS:
-            ref: "default (list) .EXCLUDE_PATHS"
+          EXCLUDE_PATTERNS:
+            ref: "default (list) .EXCLUDE_PATTERNS"
           OUTPUT_FILE: "{{.TMP_CHECKSUM_FILE}}"
       - defer: "rm -f '{{.TMP_CHECKSUM_FILE}}'"
       # Check that the paths exist and the checksum matches; otherwise delete the checksum file.
@@ -157,7 +160,7 @@ tasks:
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
   # @param {string={{.BUILD_DIR}}.md5} [CHECKSUM_FILE] Path to store the checksum of built files.
   # @param {string=""} [CMAKE_ARGS] Any additional arguments to pass to CMake's configure step.
-  cmake-build:
+  cmake-config-and-build:
     label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
     internal: true
     vars:
@@ -169,15 +172,13 @@ tasks:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     sources:
       - "{{.SOURCE_DIR}}/**/*"
-      - exclude: "{{.SOURCE_DIR}}/.cache/**/*"
-      - exclude: "{{.SOURCE_DIR}}/compile_commands.json"
     generates: ["{{.CHECKSUM_FILE}}"]
     deps:
       - task: "validate-checksum"
         vars:
           CHECKSUM_FILE: "{{.CHECKSUM_FILE}}"
           DATA_PATHS: ["{{.BUILD_DIR}}"]
-          EXCLUDE_PATHS: ["install_manifest.txt"]
+          EXCLUDE_PATTERNS: ["install_manifest.txt"]
     cmds:
       - >-
         cmake
@@ -241,7 +242,7 @@ tasks:
   # Runs curl to download a file from the given URL.
   #
   # @param {string} URL
-  # @param {string} URL_SHA256 Content hash to verify downloaded file against.
+  # @param {string} FILE_SHA256 Content hash to verify downloaded file against.
   # @param {string={{(base .URL)}}} [OUTPUT_FILE] Path where the file should be stored.
   curl:
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
@@ -249,12 +250,12 @@ tasks:
     vars:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
     requires:
-      vars: ["URL", "URL_SHA256"]
+      vars: ["URL", "FILE_SHA256"]
     generates: ["{{.OUTPUT_FILE}}"]
     status:
       - >-
         diff
-        <(echo "{{.URL_SHA256}}")
+        <(echo "{{.FILE_SHA256}}")
         <(openssl dgst -sha256 "{{.OUTPUT_FILE}}"
         | awk '{print $2}')
     cmds:
@@ -263,8 +264,14 @@ tasks:
         max_attempts=3
         attempt=1
         while [ $attempt -le $max_attempts ]; do
-          if curl --fail --location --show-error --connect-timeout 10 --max-time 300 \
-              --location "{{.URL}}" --output "{{.OUTPUT_FILE}}";
+          if curl \
+              --fail \
+              --location \
+              --show-error \
+              --connect-timeout 10 \
+              --max-time 300 \
+              "{{.URL}}" \
+              --output "{{.OUTPUT_FILE}}";
           then
             break
           fi
@@ -281,12 +288,13 @@ tasks:
   #
   # @param {string} OUTPUT_DIR Directory in which to extract the tarball.
   # @param {string} URL
-  # @param {string} URL_SHA256 Content hash to verify downloaded tar file against.
+  # @param {string} FILE_SHA256 Content hash to verify downloaded tar file against.
   # @param {string={{.OUTPUT_DIR}}.md5} [CHECKSUM_FILE] File path to store the checksum of
   # downloaded tar file.
   # @param {string[]=[]} [EXCLUDE_PATHS] Wildcard patterns for paths that shouldn't be extracted.
   # @param {string[]=[]} [INCLUDE_PATHS] Wildcard patterns for paths to extract.
-  # @param {int=1} [STRIP] Number of leading path components to strip from the extracted files.
+  # @param {int=1} [NUM_COMPONENTS_TO_STRIP] Number of leading path components to strip from the
+  # extracted files.
   # @param {string={{.OUTPUT_DIR}}.tar.gz} [TAR_FILE] Path where the tarball should be stored.
   download-and-extract-tar:
     label: "{{.TASK}}-{{.OUTPUT_DIR}}"
@@ -294,22 +302,22 @@ tasks:
     vars:
       CHECKSUM_FILE: >-
         {{default (printf "%s.md5" .OUTPUT_DIR) .CHECKSUM_FILE}}
-      EXCLUDE_PATHS:
-        ref: "default (list) .EXCLUDE_PATHS"
+      EXCLUDE_PATTERNS:
+        ref: "default (list) .EXCLUDE_PATTERNS"
       INCLUDE_PATHS:
         ref: "default (list) .INCLUDE_PATHS"
-      STRIP: "{{default 1 .STRIP}}"
+      NUM_COMPONENTS_TO_STRIP: "{{default 1 .NUM_COMPONENTS_TO_STRIP}}"
       TAR_FILE: >-
         {{default (printf "%s.tar.gz" .OUTPUT_DIR) .TAR_FILE}}
     requires:
-      vars: ["OUTPUT_DIR", "URL", "URL_SHA256"]
+      vars: ["OUTPUT_DIR", "URL", "FILE_SHA256"]
     sources: ["{{.TASKFILE}}"]
     generates: ["{{.CHECKSUM_FILE}}", "{{.TAR_FILE}}"]
     deps:
       - task: "curl"
         vars:
           URL: "{{.URL}}"
-          URL_SHA256: "{{.URL_SHA256}}"
+          FILE_SHA256: "{{.FILE_SHA256}}"
           OUTPUT_FILE: "{{.TAR_FILE}}"
       - task: "validate-checksum"
         vars:
@@ -320,14 +328,20 @@ tasks:
         rm -rf "{{.OUTPUT_DIR}}"
         mkdir -p "{{.OUTPUT_DIR}}"
       - >-
-        tar --extract
-        --strip-components="{{.STRIP}}"
+        tar
+        --extract
+        --strip-components="{{.NUM_COMPONENTS_TO_STRIP}}"
         --directory "{{.OUTPUT_DIR}}"
         --file "{{.TAR_FILE}}"
-        --wildcards
         --no-anchored
-        {{- range .INCLUDE_PATHS}} "{{.}}" {{- end}}
-        {{- range .EXCLUDE_PATHS}} --exclude="{{.}}" {{- end}}
+        --wildcards
+        {{- range .EXCLUDE_PATTERNS}}
+        --exclude="{{.}}"
+        {{- end}}
+        {{- range .DATA_PATHS}}
+        "{{.}}"
+        {{- end}}
+        2> /dev/null
       # This command must be last
       - task: "compute-checksum"
         vars:


### PR DESCRIPTION
# Description
This PR adds two new sets of utility tasks, while also updating the checksum util tasks.

#### cmake utils
This PR adds two new tasks related to building a cmake project. The first runs build and configure, while the second performs the installation. Separating these tasks allows up to build a project once, but install it multiple times to different locations.

#### remote utils
The main utility task is `fetch-src` which will download and extract a remote tar ball. The `curl` task is separated out to allow directly downloading any files.

#### checksum utils
Previously the checksum utils only operated on a single data path, which is an issue for tasks that generate files across multiple directories. This PR just changes the arguments to be an array of paths rather than a single path.


# Validation performed
Used in ffi-go irv2 beta branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced checksum computation and validation tasks now support multiple input paths using wildcard patterns.
	- Introduced new tasks for CMake operations (`cmake-config-and-build`, `cmake-install`) and remote file handling (`curl`, `download-and-extract-tar`).
- **Bug Fixes**
	- Improved error handling to prevent task failures during checksum operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->