### PR TITLE
feat(cli): Add cli script for running clang-tidy in parallel.

### DIFF
--- a/cli/clang-tidy-utils/.gitignore
+++ b/cli/clang-tidy-utils/.gitignore
@@ -1,0 +1,10 @@
+# Environment
+venv*/
+__pycache__
+
+# Packaging
+*.egg-info
+
+# Dev
+.mypy_cache
+.ruff_cache

--- a/cli/clang-tidy-utils/README.md
+++ b/cli/clang-tidy-utils/README.md
@@ -1,0 +1,31 @@
+# yscope-clang-tidy-utils
+
+This project contains CLI scripts for running [clang-tidy][clang-tidy-home] checks.
+
+## Installation
+```shell
+python3 -m pip install .
+```
+Note:
+- Python 3.10 or higher is required.
+- It is highly suggested to install in a virtual environment.
+
+## Usage
+```shell
+yscope-clang-tidy-utils [-h] [-j NUM_JOBS] FILE [FILE ...] [-- CLANG-TIDY-ARGS ...]
+```
+Note:
+- By default, the number of jobs will be set to the number of cores in the running environment.
+- Anything after `--` will be considered as clang-tidy arguments and will be directly passed into
+  clang-tidy.
+
+## Development:
+```shell
+pip install -e .[dev]
+mypy src
+docformatter -i src
+black src
+ruff check --fix src
+```
+
+[clang-tidy-home]: https://clang.llvm.org/extra/clang-tidy/

--- a/cli/clang-tidy-utils/pyproject.toml
+++ b/cli/clang-tidy-utils/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools >= 61.0", "setuptools_scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "yscope-clang-tidy-utils"
+version = "0.0.1"
+authors = [
+    { name="zhihao lin", email="lin.zhihao@yscope.com" },
+]
+requires-python = ">=3.10"
+dependencies = [
+    "clang-tidy >= 19.1.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "black >= 24.10.0",
+    "docformatter >= 1.7.5",
+    "mypy >= 1.14.1",
+    "ruff >= 0.9.2",
+]
+
+[project.scripts]
+yscope-clang-tidy-utils = "yscope_clang_tidy_utils.cli:main"
+
+[tool.black]
+line-length = 100
+target-version = ["py311"]
+color = true
+preview = true
+
+[tool.docformatter]
+make-summary-multi-line = true
+pre-summary-newline = true
+recursive = true
+wrap-summaries = 100
+wrap-descriptions = 100
+
+[tool.mypy]
+explicit_package_bases = true
+strict = true
+pretty = true
+
+[tool.ruff]
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "I", "F"]
+isort.order-by-type = false

--- a/cli/clang-tidy-utils/src/yscope_clang_tidy_utils/cli.py
+++ b/cli/clang-tidy-utils/src/yscope_clang_tidy_utils/cli.py
@@ -1,0 +1,175 @@
+import argparse
+import asyncio
+import dataclasses
+import multiprocessing
+import subprocess
+import sys
+from typing import List, Optional
+
+
+@dataclasses.dataclass
+class ClangTidyResult:
+    """
+    Class that represents clang-tidy's execution results.
+    """
+
+    file_name: str
+    ret_code: int
+    stdout: str
+    stderr: str
+
+
+def create_clang_tidy_task_arg_list(file: str, clang_tidy_args: List[str]) -> List[str]:
+    """
+    :param file: The file to check.
+    :param clang_tidy_args: The clang-tidy cli arguments.
+    :return: A list of arguments to run clang-tidy to check the given file with the given args.
+    """
+    args: List[str] = ["clang-tidy", file]
+    args.extend(clang_tidy_args)
+    return args
+
+
+async def execute_clang_tidy_task(file: str, clang_tidy_args: List[str]) -> ClangTidyResult:
+    """
+    Executes a single clang-tidy task by checking one file using a process managed by asyncio.
+
+    :param file: The file to check.
+    :param clang_tidy_args: The clang-tidy cli arguments.
+    :return: Execution results represented by an instance of `ClangTidyResult`.
+    """
+    task_args: List[str] = create_clang_tidy_task_arg_list(file, clang_tidy_args)
+    try:
+        process = await asyncio.create_subprocess_exec(
+            *task_args, stdout=subprocess.PIPE, stderr=subprocess.PIPE
+        )
+        stdout, stderr = await process.communicate()
+    except asyncio.CancelledError:
+        process.terminate()
+        await process.wait()
+        raise
+
+    assert process.returncode is not None
+    return ClangTidyResult(
+        file,
+        process.returncode,
+        stdout.decode("UTF-8"),
+        stderr.decode("UTF-8"),
+    )
+
+
+async def execute_clang_tidy_task_with_sem(
+    sem: asyncio.Semaphore, file: str, clang_tidy_args: List[str]
+) -> ClangTidyResult:
+    """
+    Wrapper of `execute_clang_tidy_task` with a global semaphore for concurrency control.
+
+    :param sem: The global semaphore for concurrency control.
+    :param file: The file to check.
+    :param clang_tidy_args: The clang-tidy cli arguments.
+    :return: Forwards `execute_clang_tidy_task`'s return values.
+    """
+    async with sem:
+        return await execute_clang_tidy_task(file, clang_tidy_args)
+
+
+async def clang_tidy_parallel_execution_entry(
+    num_jobs: int,
+    files: List[str],
+    clang_tidy_args: List[str],
+) -> int:
+    """
+    Async entry for running clang-tidy checks in parallel.
+
+    :param num_jobs: The maximum number of jobs allowed to run in parallel.
+    :param files: The list of files to check. :clang_tidy_args: The clang-tidy cli arguments.
+    """
+    sem: asyncio.Semaphore = asyncio.Semaphore(num_jobs)
+    tasks: List[asyncio.Task[ClangTidyResult]] = [
+        asyncio.create_task(execute_clang_tidy_task_with_sem(sem, file, clang_tidy_args))
+        for file in files
+    ]
+    num_total_files: int = len(files)
+
+    ret_code: int = 0
+    try:
+        for idx, clang_tidy_task in enumerate(asyncio.as_completed(tasks)):
+            result: ClangTidyResult = await clang_tidy_task
+            if 0 != result.ret_code:
+                ret_code = 1
+            print(f"[{idx + 1}/{num_total_files}]: {result.file_name}")
+            print(result.stdout)
+            print(result.stderr)
+    except asyncio.CancelledError as e:
+        print(f"\nAll tasks cancelled: {e}")
+        for task in tasks:
+            task.cancel()
+
+    return ret_code
+
+
+def main() -> None:
+    parser: argparse.ArgumentParser = argparse.ArgumentParser(
+        description="yscope-clang-tidy-utils cli options.",
+    )
+
+    parser.add_argument(
+        "-j",
+        "--num-jobs",
+        type=int,
+        help="Number of jobs to run for parallel processing.",
+    )
+
+    parser.add_argument(
+        "input_files",
+        metavar="FILE",
+        type=str,
+        nargs="+",
+        help="Input files to process.",
+    )
+
+    default_parser_usage: str = parser.format_usage()
+    if default_parser_usage.endswith("\n"):
+        default_parser_usage = default_parser_usage[:-1]
+    usage_prefix: str = "usage: "
+    if default_parser_usage.startswith(usage_prefix):
+        default_parser_usage = default_parser_usage[len(usage_prefix):]
+    usage: str = default_parser_usage + " [-- CLANG-TIDY-ARGS ...]"
+    parser.usage = usage
+
+    args: List[str] = sys.argv[1:]
+    delimiter_idx: Optional[int] = None
+    try:
+        delimiter_idx = args.index("--")
+    except ValueError:
+        pass
+
+    cli_args: List[str] = args
+    clang_tidy_args: List[str] = []
+    if delimiter_idx is not None:
+        cli_args = args[:delimiter_idx]
+        clang_tidy_args = args[delimiter_idx + 1 :]
+
+    parsed_cli_args: argparse.Namespace = parser.parse_args(cli_args)
+
+    num_jobs: int
+    if parsed_cli_args.num_jobs is not None:
+        num_jobs = parsed_cli_args.num_jobs
+    else:
+        num_jobs = multiprocessing.cpu_count()
+
+    ret_code: int = 0
+    try:
+        ret_code = asyncio.run(
+            clang_tidy_parallel_execution_entry(
+                num_jobs, parsed_cli_args.input_files, clang_tidy_args
+            )
+        )
+    except KeyboardInterrupt:
+        pass
+
+    exit(ret_code)
+
+
+if "__main__" == __name__:
+    main()


### PR DESCRIPTION
<!--
Set the PR title to a meaningful commit message in imperative form. E.g.:

clp-s: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR introduces a cli sub-project for running clang-tidy in parallel. For now, it is almost like a simplified script of the llvm version [here](https://github.com/llvm/llvm-project/blob/main/clang-tools-extra/clang-tidy/tool/run-clang-tidy.py#L499-L534).


# Validation performed
<!-- Describe what tests and validation you performed on the change. -->
I have tested this cli by using it to check clp-ffi-py. Here's how it works:
```shell
python3 -m venv venv
. ./venv/bin/activate
cd $PROJECT_DIR/yscope-dev-utils/cli/clang-tidy-utils
pip install .
cd $PROJECT_DIR/clp-ffi-py
task lint:cpp-format-fix # This is to ensure clang-tidy config has been set
rm -rf build && mkdir build && cd build && cmake .. && cd ..
yscope-clang-tidy-utils -j 10 ./src/clp_ffi_py/ir/native/* -- -p build/compile_commands.json  --line-filter="[{\"name\":\"cpp11_zone.hpp\",\"lines\":[[197,197]]}]"
```
Here, we parallel 10 clang-tidy tasks with extra clang-tidy arguments `-p build/compile_commands.json  --line-filter="[{\"name\":\"cpp11_zone.hpp\",\"lines\":[[197,197]]}]"` to match what we specify in the linting task [here](https://github.com/y-scope/clp-ffi-py/blob/2595c70b93b34d7326039a97e723d6e4fbc8d893/lint-tasks.yml#L107). You can use `echo $?` to check the return value is 0. If we remove the lint filter in the arguments above, clang-tidy will raise a warning on msgpack's source code and thus the return value of `echo $?` will be 1 in this case.
