### PR TITLE
chore(taskfiles)!: Split up cmake-config-and-build; Add cmake-clean.

### DIFF
--- a/taskfiles/utils-cmake.yaml
+++ b/taskfiles/utils-cmake.yaml
@@ -4,21 +4,59 @@ set: ["u", "pipefail"]
 shopt: ["globstar"]
 
 tasks:
-  # Runs CMake's configure and build steps for the given source and build directories.
+  # Runs the CMake build step for the given build directory. The caller must have previously called
+  # `cmake-generate` on `BUILD_DIR` for this task to succeed. We purposely omit `sources` and
+  # `generates` as we defer to `cmake` to decide whether it should perform any actions.
   #
-  # @param {string} BUILD_DIR CMake build directory to create.
-  # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
+  # @param {string} BUILD_DIR Directory containing the generated buildsystem to use.
+  # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
   # omitted, the native build tool's default number is used. See `man cmake`.
-  # @param {string} [CONF_ARGS] Any additional arguments to pass to CMake's configure step.
-  cmake-config-and-build:
+  # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
+  cmake-build:
     internal: true
-    label: "{{.TASK}}-{{.SOURCE_DIR}}-{{.BUILD_DIR}}"
-    vars:
-      CONF_ARGS: >-
-        {{default "" .CONF_ARGS}}
-      JOBS: >-
-        {{default "" .JOBS}}
+    label: "{{.TASK}}:{{.BUILD_DIR}}-{{.TARGETS}}-{{.EXTRA_ARGS}}"
+    requires:
+      vars: ["BUILD_DIR"]
+    cmds:
+      - >-
+        cmake
+        --build "{{.BUILD_DIR}}"
+        --parallel "{{.JOBS}}"
+        {{- range .TARGETS}}
+        --target="{{.}}"
+        {{- end}}
+        {{- range .EXTRA_ARGS}}
+        "{{.}}"
+        {{- end}}
+
+  # Runs the CMake clean target for the given build directory. The caller must have previously
+  # called `cmake-generate` on `BUILD_DIR` for this task to succeed.
+  #
+  # @param {string} BUILD_DIR Directory containing the generated buildsystem to use.
+  # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass with the clean target.
+  cmake-clean:
+    internal: true
+    requires:
+      vars: ["BUILD_DIR"]
+    cmds:
+      - task: "cmake-build"
+        vars:
+          BUILD_DIR: "{{.BUILD_DIR}}"
+          EXTRA_ARGS:
+            ref: "default (list) .EXTRA_ARGS"
+          TARGETS: ["clean"]
+
+  # Runs the CMake generate step for the given source and build directories.
+  # We purposely omit `sources` and `generates` as we defer to `cmake` to decide whether it should
+  # perform any actions.
+  #
+  # @param {string} BUILD_DIR Directory to generate the buildsystem inside.
+  # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
+  # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the generate command.
+  cmake-generate:
+    internal: true
+    label: "{{.TASK}}:{{.SOURCE_DIR}}-{{.BUILD_DIR}}-{{.EXTRA_ARGS}}"
     requires:
       vars: ["BUILD_DIR", "SOURCE_DIR"]
     cmds:
@@ -26,19 +64,20 @@ tasks:
         cmake
         -S "{{.SOURCE_DIR}}"
         -B "{{.BUILD_DIR}}"
-        {{.CONF_ARGS}}
-      - >-
-        cmake
-        --build "{{.BUILD_DIR}}"
-        --parallel "{{.JOBS}}"
+        {{- range .EXTRA_ARGS}}
+        "{{.}}"
+        {{- end}}
 
-  # Runs the CMake install step for the given build directory.
+  # Runs the CMake install step for the given build directory. The caller must have previously
+  # called `cmake-build` on `BUILD_DIR` for this task to succeed. We purposely omit `sources` and
+  # `generates` as we defer to `cmake` to decide whether it should perform any actions.
   #
-  # @param {string} BUILD_DIR CMake build directory.
+  # @param {string} BUILD_DIR Directory containing the completed build to use.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
+  # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
   cmake-install:
     internal: true
-    label: "{{.TASK}}-{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}"
+    label: "{{.TASK}}:{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}-{{.EXTRA_ARGS}}"
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     cmds:
@@ -46,3 +85,6 @@ tasks:
         cmake
         --install "{{.BUILD_DIR}}"
         --prefix "{{.INSTALL_PREFIX}}"
+        {{- range .EXTRA_ARGS}}
+        "{{.}}"
+        {{- end}}

--- a/taskfiles/utils-cmake.yaml
+++ b/taskfiles/utils-cmake.yaml
@@ -8,7 +8,7 @@ tasks:
   # `cmake-generate` on `BUILD_DIR` for this task to succeed. We purposely omit `sources` and
   # `generates` as we defer to `cmake` to decide whether it should perform any actions.
   #
-  # @param {string} BUILD_DIR Directory containing the generated buildsystem to use.
+  # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
   # omitted, the native build tool's default number is used. See `man cmake`.
@@ -47,11 +47,11 @@ tasks:
             ref: "default (list) .EXTRA_ARGS"
           TARGETS: ["clean"]
 
-  # Runs the CMake generate step for the given source and build directories.
-  # We purposely omit `sources` and `generates` as we defer to `cmake` to decide whether it should
-  # perform any actions.
+  # Runs the CMake generate step for the given source and build directories. We purposely omit
+  # `sources` and `generates` as we defer to `cmake` to decide whether it should perform any
+  # actions.
   #
-  # @param {string} BUILD_DIR Directory to generate the buildsystem inside.
+  # @param {string} BUILD_DIR Directory in which to generate the build system.
   # @param {string} SOURCE_DIR Project source directory containing the CMakeLists.txt file.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the generate command.
   cmake-generate:


### PR DESCRIPTION
# Description

This PR breaks up `cmake-config-and-build` into `cmake-generate` and `cmake-build`. Additionally, it adds `cmake-clean` and improves the docstrings for each task.

The notable decisions in our design are:
* We do not use `sources` or `generates` and defer decision making to `cmake` to ensure expected and reliable behaviour.
* We leave it up to the user/caller to ensure the proper dependencies between tasks are met (e.g. calling generate before build).
    * Adding dependencies causes a task to require all the arguments of its dependent tasks to be run correctly (i.e. install becomes a superset of build and generate, build becomes a superset of generate). This can lead to unexpected behaviour as a change in any argument could lead to re-generating and re-building the project with different arguments.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested with various tasks in `clp`.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new `cmake-clean` command to enhance cleaning operations.
	- Expanded command options with `EXTRA_ARGS` and `TARGETS` for more flexible build configurations.

- **Chores**
	- Updated task definitions and clarified dependencies for improved workflow understanding.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->