### PR TITLE
fix: Force `utils:curl` to run when input urls or commit hash for the library target to be downloaded changes.

### DIFF
--- a/taskfiles/utils-remote.yaml
+++ b/taskfiles/utils-remote.yaml
@@ -14,10 +14,15 @@ tasks:
     label: "{{.TASK}}-{{.OUTPUT_FILE}}"
     vars:
       OUTPUT_FILE: "{{default (base .URL) .OUTPUT_FILE}}"
+      URL_FILE: "{{.OUTPUT_FILE | replace \".\" \"#\"}}.url"
     requires:
       vars: ["FILE_SHA256", "URL"]
-    generates: ["{{.OUTPUT_FILE}}"]
+    generates: ["{{.OUTPUT_FILE}}, {{.URL_FILE}}"]
     status:
+      - >-
+        diff
+        <(echo "{{.URL}}")
+        <(cat "{{.URL_FILE}}")
       - >-
         diff
         <(echo "{{.FILE_SHA256}}")
@@ -26,6 +31,7 @@ tasks:
     cmds:
       - |-
         mkdir -p "{{dir .OUTPUT_FILE}}"
+        echo "{{.URL}}" > "{{.URL_FILE}}"
         max_attempts=3
         attempt=1
         while [ $attempt -le $max_attempts ]; do
@@ -47,6 +53,11 @@ tasks:
           echo "Failed to download after $max_attempts attempts."
           exit 1
         fi
+      - >-
+        diff
+        <(echo "{{.FILE_SHA256}}")
+        <(openssl dgst -sha256 "{{.OUTPUT_FILE}}"
+        | awk '{print $2}')
 
   # Runs curl to download the tar file from the given URL and extracts its contents.
   #

--- a/taskfiles/utils-remote.yaml
+++ b/taskfiles/utils-remote.yaml
@@ -53,6 +53,7 @@ tasks:
           echo "Failed to download after $max_attempts attempts."
           exit 1
         fi
+      - "echo Verifying the commit hash of {{.OUTPUT_FILE}}."
       - >-
         diff
         <(echo "{{.FILE_SHA256}}")


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [X] Tested extensively in [`ystdlib-cpp`](https://github.com/y-scope/ystdlib-cpp/pull/25) by stimulating the adjusting of input arguments to `utils:curl`.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
