### PR TITLE
Remove absolute namespace path from task names in `utils-cmake.yaml`.

### DIFF
--- a/taskfiles/utils-cmake.yaml
+++ b/taskfiles/utils-cmake.yaml
@@ -167,19 +167,19 @@ tasks:
     requires:
       vars: ["FILE_SHA256", "NAME", "URL"]
     deps:
-      - task: ":utils:download-and-extract-tar"
+      - task: "download-and-extract-tar"
         vars:
           FILE_SHA256: "{{.FILE_SHA256}}"
           OUTPUT_DIR: "{{.SOURCE_DIR}}"
           URL: "{{.URL}}"
     cmds:
-      - task: ":utils:cmake-generate"
+      - task: "cmake-generate"
         vars:
           BUILD_DIR: "{{.BUILD_DIR}}"
           EXTRA_ARGS:
             ref: ".GEN_ARGS"
           SOURCE_DIR: "{{.SOURCE_DIR}}"
-      - task: ":utils:cmake-build"
+      - task: "cmake-build"
         vars:
           BUILD_DIR: "{{.BUILD_DIR}}"
           EXTRA_ARGS:
@@ -187,7 +187,7 @@ tasks:
           JOBS: "{{.JOBS}}"
           TARGETS:
             ref: ".TARGETS"
-      - task: ":utils:cmake-install"
+      - task: "cmake-install"
         vars:
           BUILD_DIR: "{{.BUILD_DIR}}"
           EXTRA_ARGS:


### PR DESCRIPTION
# Description

A previous PR incorrectly used absolute namespace paths for some task names in `utils-cmake.yaml`. These tasks refer to other local tasks in the same file so adding an absolute namespace path means the file must always be (unnecessarily) included in a specific way.

For example, `task: ":utils:cmake-build"` explicitly looks up a `utils` namespace inside the global namespace, and then a `cmake-build` task within that `utils` namespace. If `utils-cmake.yaml` or `utils.yaml` were to be included under a different name or layered under another include statement, this task name would be incorrect and not found.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested in a locally with clp.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Simplified internal configuration to streamline operations. Refined naming conventions were applied to improve consistency and maintainability. This update is part of ongoing enhancements that bolster system robustness and operational efficiency. As a result, users will continue to experience a seamless interface while the underlying improvements prepare the system for future upgrades without altering current functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->