### PR TITLE
fix(taskfiles): Add missing backslash in `cpp-lint:clang-format`.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -78,7 +78,7 @@ tasks:
             {{- end}}
           \) \
         {{- end}}
-        -print0
+        -print0 \
       | xargs -0 clang-format \
         {{- range .FLAGS}}
           {{.}} \


### PR DESCRIPTION
# Description

As title says.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Validated in local clp branch.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined internal formatting configuration to ensure smoother command execution during automated style checking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->