### PR TITLE
fix(taskfile): Change `xargs --no-run-if-empty` to `xargs -I{}` to be portable between GNU and BSD's `xargs`.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -140,7 +140,7 @@ tasks:
       DIFF_SOURCE_FILE_PATHS_:
         sh: >-
           git diff --name-only --ignore-submodules "{{.GIT_REF}}" **/*.{cpp,h,hpp}
-          | xargs --no-run-if-empty realpath
+          | xargs -I{} realpath
       DIFF_SOURCE_FILE_PATHS:
         ref: >-
           compact (splitList "\n" .DIFF_SOURCE_FILE_PATHS_)


### PR DESCRIPTION
# Description

As title says. This allows usage on macos without installing GNU utils.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested with local tasks.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Refined the internal process for handling modified file inputs to ensure consistent execution of code quality checks, even when no files are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->