### PR TITLE
fix(clang-tidy-diff): Add missing placeholder in xargs command; Set `pipefail` to detect `git diff` failures before xargs.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -138,6 +138,8 @@ tasks:
       GIT_REF: >-
         {{default "origin/HEAD" .GIT_REF}}
       DIFF_SOURCE_FILE_PATHS_:
+        # NOTE: Although we have pipefail set globally in this file, it doesn't seem to apply here;
+        # so we need to set it again.
         sh: >-
           set -o pipefail;
           git diff --name-only --ignore-submodules "{{.GIT_REF}}" -- **/*.{cpp,h,hpp}

--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -141,7 +141,7 @@ tasks:
         sh: >-
           set -o pipefail;
           git diff --name-only --ignore-submodules "{{.GIT_REF}}" -- **/*.{cpp,h,hpp}
-          | xargs -I{} realpath
+          | xargs -I{} realpath {}
       DIFF_SOURCE_FILE_PATHS:
         ref: >-
           compact (splitList "\n" .DIFF_SOURCE_FILE_PATHS_)

--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -136,7 +136,7 @@ tasks:
     label: "{{.TASK}}:{{.OUTPUT_DIR}}"
     vars:
       GIT_REF: >-
-        {{default "origin/HEAD" .GIT_REF}}
+        {{default "origin/main" .GIT_REF}}
       DIFF_SOURCE_FILE_PATHS_:
         # NOTE: Although we have pipefail set globally in this file, it doesn't seem to apply here;
         # so we need to set it again.

--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -136,10 +136,11 @@ tasks:
     label: "{{.TASK}}:{{.OUTPUT_DIR}}"
     vars:
       GIT_REF: >-
-        {{default "origin/main" .GIT_REF}}
+        {{default "origin/HEAD" .GIT_REF}}
       DIFF_SOURCE_FILE_PATHS_:
         sh: >-
-          git diff --name-only --ignore-submodules "{{.GIT_REF}}" **/*.{cpp,h,hpp}
+          set -o pipefail;
+          git diff --name-only --ignore-submodules "{{.GIT_REF}}" -- **/*.{cpp,h,hpp}
           | xargs -I{} realpath
       DIFF_SOURCE_FILE_PATHS:
         ref: >-


### PR DESCRIPTION
# Description

This PR contains 2 small fixes to `clang-tidy-diff`:
1. In #30 `xargs -I{} realpath` should be `xargs -I{} realpath {}`. Without the ending `{}` no argument is passed to `realpath`.
2. In a taskfile, when setting a variable with `sh` task doesn't respect a taskfile's `set` statements. Therefore, we manually set `pipefail` before calling `git diff` so that if there is an error it is returned rather than piping empty output to `xargs`.


# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested locally through CLP.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated the internal code quality checking process for C++ to enhance error handling in file modification detection, ensuring more reliable code analysis and contributing to a stable development environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->