### PR TITLE
refactor(taskfile): Change the default git reference to `origin/HEAD` in `clang-tidy-diff`.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -136,7 +136,7 @@ tasks:
     label: "{{.TASK}}:{{.OUTPUT_DIR}}"
     vars:
       GIT_REF: >-
-        {{default "origin/main" .GIT_REF}}
+        {{default "origin/HEAD" .GIT_REF}}
       DIFF_SOURCE_FILE_PATHS_:
         sh: >-
           git diff --name-only --ignore-submodules "{{.GIT_REF}}" **/*.{cpp,h,hpp}


### PR DESCRIPTION
# Description

As title says.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested locally with CLP.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
