### PR TITLE
fix(clang-tidy-diff): Correct `GIT_REF`'s default value in docstring.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -128,7 +128,7 @@ tasks:
   # indirectly), making it possible for all modified files to pass, but unmodified files to fail.
   #
   # @param {string} VENV_DIR Python virtual environment where `clang-tidy` is installed.
-  # @param {string} [GIT_REF="origin/main"] The `git` reference to diff against HEAD.
+  # @param {string} [GIT_REF="origin/HEAD"] The `git` reference to diff against HEAD.
   # @param {string[]} [FLAGS] Any flags to pass to `clang-tidy`.
   # @param {string} [OUTPUT_DIR="{{.ROOT_DIR}}/lint-clang-tidy"]
   clang-tidy-diff:


### PR DESCRIPTION
# Description

As title says.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

NA



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the default branch reference used for code quality checks, ensuring that comparisons align with the current branch state when no specific reference is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->