### PR TITLE
feat(lint-configs): Update the clang-format config for clang-format v20.

### DIFF
--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -27,6 +27,7 @@ AllowShortFunctionsOnASingleLine: "Inline"
 AllowShortIfStatementsOnASingleLine: "Never"
 AllowShortLambdasOnASingleLine: "All"
 AllowShortLoopsOnASingleLine: false
+AllowShortNamespacesOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: false
 BinPackParameters: false
@@ -56,6 +57,7 @@ BreakBeforeBraces: "Custom"
 BreakBeforeConceptDeclarations: "Always"
 BreakBeforeInlineASMColon: "OnlyMultiline"
 BreakBeforeTernaryOperators: true
+BreakBinaryOperations: "RespectPrecedence"
 BreakConstructorInitializers: "BeforeColon"
 BreakFunctionDefinitionParameters: false
 BreakInheritanceList: "BeforeColon"
@@ -74,6 +76,7 @@ IncludeBlocks: "Regroup"
 IndentAccessModifiers: false
 IndentCaseBlocks: false
 IndentCaseLabels: true
+IndentExportBlock: true
 IndentExternBlock: "Indent"
 IndentGotoLabels: false
 IndentPPDirectives: "BeforeHash"
@@ -92,6 +95,7 @@ KeepEmptyLines:
   AtEndOfFile: true
   AtStartOfBlock: false
   AtStartOfFile: false
+KeepFormFeed: false
 LambdaBodyIndentation: "Signature"
 LineEnding: "LF"
 MainIncludeChar: "Quote"
@@ -101,6 +105,7 @@ PPIndentWidth: -1
 PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25
 PenaltyBreakBeforeFirstCallParameter: 25
+PenaltyBreakBeforeMemberAccess: 25
 PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: "Left"
 QualifierAlignment: "Custom"
@@ -116,6 +121,7 @@ QualifierOrder:
 ReferenceAlignment: "Pointer"
 ReflowComments: true
 RemoveBracesLLVM: false
+RemoveEmptyLinesInUnwrappedLines: true
 RemoveSemicolon: true
 RequiresClausePosition: "OwnLine"
 RequiresExpressionIndentation: "OuterScope"
@@ -153,3 +159,4 @@ SpacesInSquareBrackets: false
 Standard: "Latest"
 TabWidth: 4
 UseTab: "Never"
+WrapNamespaceBodyWithEmptyLines: "Never"

--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -57,7 +57,7 @@ BreakBeforeBraces: "Custom"
 BreakBeforeConceptDeclarations: "Always"
 BreakBeforeInlineASMColon: "OnlyMultiline"
 BreakBeforeTernaryOperators: true
-BreakBinaryOperations: "RespectPrecedence"
+BreakBinaryOperations: "Never"
 BreakConstructorInitializers: "BeforeColon"
 BreakFunctionDefinitionParameters: false
 BreakInheritanceList: "BeforeColon"
@@ -119,7 +119,7 @@ QualifierOrder:
   - "const"
   - "volatile"
 ReferenceAlignment: "Pointer"
-ReflowComments: true
+ReflowComments: "Always"
 RemoveBracesLLVM: false
 RemoveEmptyLinesInUnwrappedLines: true
 RemoveSemicolon: true

--- a/lint-configs/lint-requirements.txt
+++ b/lint-configs/lint-requirements.txt
@@ -1,4 +1,3 @@
-# Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
-clang-format~=18.1
-clang-tidy>=20.1.0
+clang-format>=20.1.0
+clang-tidy>=19.1.0
 yamllint>=1.35.1

--- a/lint-configs/lint-requirements.txt
+++ b/lint-configs/lint-requirements.txt
@@ -1,4 +1,4 @@
 # Lock to v18.x until we can upgrade our code to meet v19's formatting standards.
 clang-format~=18.1
-clang-tidy>=19.1.0
+clang-tidy>=20.1.0
 yamllint>=1.35.1


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR updates the clang-format config to adapt release v20. Changes:
- `AllowShortNamespacesOnASingleLine`: Set to `false` to emphasize the namespace as a multiline block.
- `BreakBinaryOperations`: Set to `RespectPrecedence`. Potentially, this can make multiline condition expressions clearer (like `if (x || y || z ...)`), but I'm also okay with setting it to `Never`.
- `IndentExportBlock`: Make a similar style as `extern "C"` block.
- `KeepFormFeed`: Apparently, we don't have form feeds in our code base or plan to add ones. It should be safe to set it to `false`.
- `PenaltyBreakComment`: Set to the same value as other `PenaltyBreakXXX` options.
- `RemoveEmptyLinesInUnwrappedLines`: Set to true as it can be helpful.
- `WrapNamespaceBodyWithEmptyLines`: Set to `Never` which matches what we usually do for a namespace (no empty lines at the beginning or in the end).

The following new options are not added:
- `TemplateNames`: This should be a project-specific option.
- `VariableTemplates`: This should be a project-specific option.

Ref:
clang-format 20.1 doc: https://releases.llvm.org/20.1.0/tools/clang/docs/ClangFormatStyleOptions.html

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Using the updated config locally on clp to ensure clp core can be correctly formatted.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Style**
	- Enhanced code formatting rules for C++ to enforce consistent styling, including disallowing short namespaces on a single line, preventing breaks in binary operations, and improving indentation for export blocks.
- **Chores**
	- Upgraded the required version of `clang-format` to ensure compatibility with the new formatting guidelines.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->