### PR TITLE
feat(lint-configs): Update the clang-format config to remove `PenaltyBreakBeforeMemberAccess`.

### DIFF
--- a/lint-configs/.clang-format
+++ b/lint-configs/.clang-format
@@ -105,7 +105,6 @@ PPIndentWidth: -1
 PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25
 PenaltyBreakBeforeFirstCallParameter: 25
-PenaltyBreakBeforeMemberAccess: 25
 PenaltyReturnTypeOnItsOwnLine: 100
 PointerAlignment: "Left"
 QualifierAlignment: "Custom"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

`PenaltyBreakBeforeMemberAccess` has been added and set to 25 in #34. This makes clang-format prefer to use
```C++
object.
        method(x, y, z);
```
rather than
```C++
object.method(
        x,
        y,
        z
);
```

We prefer the latter style in our code base. Therefore, we decided to remove `PenaltyBreakBeforeMemberAccess` and use its default value (which is 150). This prevents most code refactoring from breaking a member's access.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Tested on clp repo to ensure breaking on a member access is avoided whenever possible.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Refined internal formatting configurations to maintain overall code consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->