### PR TITLE
fix(clang-tidy-output): Replace `tail -v` with equivalent to support macOS.

### DIFF
--- a/taskfiles/utils/cpp-lint.yaml
+++ b/taskfiles/utils/cpp-lint.yaml
@@ -293,7 +293,8 @@ tasks:
               {{- $output_path := printf "%s/%s.log" $output_dir (replace "/" "-" .)}}
               if [[ -f "{{$output_path}}" ]] \
                   && [[ "Failed" == "$(tail -n 1 {{$output_path}})" ]]; then
-                tail -v -n +1 "{{$output_path}}"
+                echo "# {{$output_path}}"
+                cat "{{$output_path}}"
               fi
             {{- end}}
           {{- end}}


### PR DESCRIPTION
# Description

As title says. macOS's version of `tail` doesn't support the `-v` flag, so we replace it with `echo` + `cat`.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested locally.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced log display for improved clarity: a header now indicates the log file location before showing its full contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->