### PR TITLE
feat(lint-configs): Disable `portability-template-virtual-member-function` check in `.clang-tidy`.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -3,6 +3,7 @@ WarningsAsErrors: "*"
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
+# - `portability-template-virtual-member-function` because we don't support MSVC compilers yet.
 # - `readability-identifier-length` because it's case-dependent.
 # - `readability-named-parameter` because we don't want to enforce that all parameters have a name.
 # - `readability-simplify-boolean-expr` because changing `false == x` to `!x` violates our style
@@ -19,6 +20,7 @@ Checks: >-
   modernize-*,
   performance-*,
   portability-*,
+  -portability-template-virtual-member-function,
   readability-*,
   -readability-identifier-length,
   -readability-named-parameter,


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

Clang-Tidy v20 introduces a new check, `-portability-template-virtual-member-function`, which raises issues with our use of virtual functions in the templated class [`ErrorCategory`](https://github.com/y-scope/ystdlib-cpp/blob/5f43a3bcacf43ceeb7b41b0442b6955064bab780/src/ystdlib/error_handling/ErrorCode.hpp#L34).

Take the `name()` function as an example: we only intend to instantiate it when a concrete `ErrorCategory` specialization exists—at which point we know the appropriate category name to return.

* GCC/Clang: works fine. Unused virtual member functions are not instantiated unless explicitly referenced. 
* MSVC: requires `name()` to be implemented/instantiated, so it will report a missing definition error, hence breaking compilation.

Since YScope projects currently don't support `MSVC` compilers on the Windows platform, we disable this check.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] No test needed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated internal code quality configurations to enhance compatibility with supported compiler environments and improve clarity in our tooling setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->