### PR TITLE
feat(clang-tidy): Enforce prefixing global variables with `g_`.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -137,7 +137,9 @@ CheckOptions:
 
   # Variable naming rules
   readability-identifier-naming.GlobalPointerCase: "lower_case"
+  readability-identifier-naming.GlobalPointerPrefix: "g_"
   readability-identifier-naming.GlobalVariableCase: "lower_case"
+  readability-identifier-naming.GlobalVariablePrefix: "g_"
   readability-identifier-naming.LocalPointerCase: "lower_case"
   readability-identifier-naming.LocalVariableCase: "lower_case"
   readability-identifier-naming.StaticVariableCase: "lower_case"


### PR DESCRIPTION
# Description

As title says.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Ran clang-tidy on CLP.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated naming standards by enforcing consistent prefixes for global pointers and variables. These configuration improvements enhance code clarity and maintainability, ensuring uniformity across the codebase. This change supports smoother development and contributes to better long-term project upkeep.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->