### PR TITLE
feat(clang-tidy): Disable function cognitive-complexity check for code inside macros.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -46,7 +46,8 @@ CheckOptions:
   # them. Instead, we explicitly specify all rules (except those that should have reasonable
   # defaults, e.g., `""` for `ClassPrefix`).
 
-  # Function cognitive complexity rules
+  # This is necessary for code that can only use macros to achieve certain functionality, like
+  # Catch2's `REQUIRE` and ystdlib's `YSTDLIB_ERROR_HANDLING_TRYX`.
   readability-function-cognitive-complexity.IgnoreMacros: true
 
   # Macro naming rules

--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -46,6 +46,9 @@ CheckOptions:
   # them. Instead, we explicitly specify all rules (except those that should have reasonable
   # defaults, e.g., `""` for `ClassPrefix`).
 
+  # Function cognitive complexity rules
+  readability-function-cognitive-complexity.IgnoreMacros: true
+
   # Macro naming rules
   readability-identifier-naming.MacroDefinitionCase: "UPPER_CASE"
 


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The function cognitive complexity check will expand the macro and count everything inside the macro, which could easily break the default threshold. We've seen this in many catch2 test cases caused by catch2's `REQUIRE` macro.

In addition, our recently introduced macro, [YSTDLIB_ERROR_HANDLING_TRYX](https://github.com/y-scope/ystdlib-cpp/blob/d3fc9804eacb3ee4f156ae0ca37151cb04847580/src/ystdlib/error_handling/Result.hpp#L46), will also cause a similar issue where the complexity threshold can be easily broken.

As a result of our offline discussion, we decided to disable the cognitive complexity check for the code inside the macro.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

- Tested offline to ensure it works.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated lint configuration to improve handling of cognitive complexity checks by ignoring macros.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->