### PR TITLE
feat(lint-configs): Add markdownlint config.

### DIFF
--- a/lint-configs/.markdownlint-cli2.yaml
+++ b/lint-configs/.markdownlint-cli2.yaml
@@ -15,6 +15,10 @@ config:
     tables: false
   MD024:
     siblings_only: true
+
+  # TODO Improve comment
+  # We use HTML tags in Mermaid diagrams.
+  MD033: false
   MD035:
     style: "---"
   MD046:
@@ -24,6 +28,11 @@ config:
   MD049:
     # We choose an asterisk to avoid confusion when emphasizing text that includes underscores.
     style: "asterisk"
+
+  # TODO Improve comment
+  # Sphinx should validate links and markdownlint doesn't support the MyST syntax for specifying
+  # arbitrary links.
+  MD051: false
   MD052:
     shortcut_syntax: true
   MD055:

--- a/lint-configs/.markdownlint-cli2.yaml
+++ b/lint-configs/.markdownlint-cli2.yaml
@@ -16,8 +16,7 @@ config:
   MD024:
     siblings_only: true
 
-  # TODO Improve comment
-  # We use HTML tags in Mermaid diagrams.
+  # `false` since we sometimes need to use HTML tags (e.g., in Mermaid diagrams, etc.).
   MD033: false
   MD035:
     style: "---"
@@ -29,9 +28,8 @@ config:
     # We choose an asterisk to avoid confusion when emphasizing text that includes underscores.
     style: "asterisk"
 
-  # TODO Improve comment
-  # Sphinx should validate links and markdownlint doesn't support the MyST syntax for specifying
-  # arbitrary links.
+  # `false` since Sphinx validate links, and markdownlint doesn't support MyST-Parser's syntax for
+  # specifying explicit targets.
   MD051: false
   MD052:
     shortcut_syntax: true

--- a/lint-configs/.markdownlint-cli2.yaml
+++ b/lint-configs/.markdownlint-cli2.yaml
@@ -1,0 +1,30 @@
+config:
+  MD003:
+    style: "atx"
+  MD004:
+    style: "asterisk"
+  MD009:
+    list_item_empty_lines: true
+    strict: true
+  MD010:
+    code_blocks: false
+    spaces_per_tab: 4
+  MD013:
+    line_length: 100
+    stern: true
+    tables: false
+  MD024:
+    siblings_only: true
+  MD035:
+    style: "---"
+  MD046:
+    style: "fenced"
+  MD048:
+    style: "backtick"
+  MD049:
+    # We choose an asterisk to avoid confusion when emphasizing text that includes underscores.
+    style: "asterisk"
+  MD052:
+    shortcut_syntax: true
+  MD055:
+    style: "leading_and_trailing"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As the title says. The config only sets rules which require different values than their defaults. The rules are documented [here](https://github.com/DavidAnson/markdownlint/blob/main/README.md#rules--aliases).

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validated with the docs in [clp](https://github.com/y-scope/clp) as follows:

```bash
npm install -g markdownlint-cli2
markdownlint-cli2 --fix docs/src/**/*.md
```

* The violations were as expected.
* Some fixes (e.g., removing the space from an inline codeblock) will require changing the docs to something that won't get fixed.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Added a new configuration file for markdown linting with customized rules to improve consistency and style in markdown documents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->