### PR TITLE
fix(lint-configs): Relax clang-tidy `misc-include-cleaner` check to a warning.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -1,5 +1,11 @@
 FormatStyle: "file"
-WarningsAsErrors: "*,-misc-include-cleaner"
+
+# Left as warnings:
+# - `misc-include-cleaner` because it's difficult to resolve iwyu issues for external libraries
+# without facade headers.
+WarningsAsErrors: >-
+  *
+  -misc-include-cleaner
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.

--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -5,7 +5,7 @@ FormatStyle: "file"
 # without facade headers.
 WarningsAsErrors: >-
   *,
-  -misc-include-cleaner
+  -misc-include-cleaner,
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.

--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -1,5 +1,5 @@
 FormatStyle: "file"
-WarningsAsErrors: "*"
+WarningsAsErrors: "*,-misc-include-cleaner"
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.

--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -1,10 +1,10 @@
 FormatStyle: "file"
 
 # Left as warnings:
-# - `misc-include-cleaner` because it's difficult to resolve iwyu issues for external libraries
+# - `misc-include-cleaner` because it's difficult to resolve IWYU issues for external libraries
 # without facade headers.
 WarningsAsErrors: >-
-  *
+  *,
   -misc-include-cleaner
 
 # Disabled checks:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Many C++ libraries expose a single "helper/meta" header that contains many other "internal" headers. This creates issues with `iwyu` style checkers like clang-tidy's `misc-include-cleaner` as these "meta" headers do not directly expose the symbols used. Previously we have gotten around this by creating [facade headers in ystdlb](https://github.com/y-scope/ystdlib-cpp/tree/main/src/ystdlib/wrapped_facade_headers), but this problem is becoming hard to keep up with.

This PR addresses this problem by relaxing `misc-include-cleaner` back to a warning so the issues will not block CI. 


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested on boost test code in #42.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated linting configuration to exclude a specific warning from being treated as an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->