### PR TITLE
refactor(taskfiles)!: Remove ability to set build/install/source-dir paths (in favour of putting them inside `WORK_DIR`) in `utils:cmake:install-remote-tar`.

### DIFF
--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -148,14 +148,6 @@ tasks:
   # project's CMake settings file should be stored.
   # @param {string[]} [CMAKE_TARGETS] A list of specific targets to build instead of the default
   # target.
-  #
-  # Directory parameters
-  # @param {string} [BUILD_DIR={{.WORK_DIR}}/{{.NAME}}-build] Directory in which to generate the
-  # build system and perform the build.
-  # @param {string} [INSTALL_PREFIX={{.WORK_DIR}}/{{.NAME}}-install] Path prefix of where the
-  # project should be installed.
-  # @param {string} [SOURCE_DIR={{.WORK_DIR}}/{{.NAME}}-src] Directory in which to extract the tar
-  # file.
   install-remote-tar:
     internal: true
     label: "{{.TASK}}:{{.NAME}}-{{.TAR_URL}}-{{.INSTALL_PREFIX}}"
@@ -175,12 +167,9 @@ tasks:
         ref: "default (list) .CMAKE_TARGETS"
 
       # Directory parameters
-      BUILD_DIR: >-
-        {{default (printf "%s/%s-build" .WORK_DIR .NAME) .BUILD_DIR}}
-      INSTALL_PREFIX: >-
-        {{default (printf "%s/%s-install" .WORK_DIR .NAME) .INSTALL_PREFIX}}
-      SOURCE_DIR: >-
-        {{default (printf "%s/%s-src" .WORK_DIR .NAME) .SOURCE_DIR}}
+      BUILD_DIR: "{{.WORK_DIR}}/{{.NAME}}-build"
+      INSTALL_PREFIX: "{{.WORK_DIR}}/{{.NAME}}-install"
+      SOURCE_DIR: "{{.WORK_DIR}}/{{.NAME}}-src"
 
     requires:
       vars: ["NAME", "TAR_SHA256", "TAR_URL", "WORK_DIR"]


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Currently there is a weird case where if all build, install, and source directory paths are specified then the required parameter `WORK_DIR` is unused.

Rather than adding logic to check the combination of variables, we're simply removing the these directory paths from being optional parameters. Since `utils:cmake:install-remote-tar` requires a working CMake project there was no reason to override these directories and existing use cases were already just letting the directories default to be inside `WORK_DIR`.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested locally with log-surgeon.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal directory path handling for remote installation tasks to use consistent default locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->