### PR TITLE
refactor(taskfiles)!: Rename `NAME` to `CMAKE_PACKAGE_NAME` and require it to be set if `CMAKE_SETTINGS_DIR` is set in `utils:cmake:install` (fixes #50).

### DIFF
--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -94,11 +94,11 @@ tasks:
   #
   # @param {string} BUILD_DIR Directory containing the completed build to use.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
+  # @param {string} [CMAKE_PACKAGE_NAME] CMake project name (used in directory names and the CMake
+  # settings file). Required if `CMAKE_SETTINGS_DIR` is set.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
-  # @param {string} [CMAKE_PACKAGE_NAME] CMake project name (used in directory names and the CMake
-  # settings file).  Required if `CMAKE_SETTINGS_DIR` is set.
   install:
     internal: true
     label: "{{.TASK}}:{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}-{{.EXTRA_ARGS}}"
@@ -206,11 +206,11 @@ tasks:
       - task: "install"
         vars:
           BUILD_DIR: "{{.BUILD_DIR}}"
+          CMAKE_PACKAGE_NAME: "{{.CMAKE_PACKAGE_NAME}}"
           CMAKE_SETTINGS_DIR: "{{.CMAKE_SETTINGS_DIR}}"
           EXTRA_ARGS:
             ref: ".CMAKE_INSTALL_ARGS"
           INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
-          CMAKE_PACKAGE_NAME: "{{.CMAKE_PACKAGE_NAME}}"
 
   # Sets up all CMake dependencies for a project by:
   #

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -98,6 +98,7 @@ tasks:
   # file should be stored.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
   # @param {string} [NAME] CMake project name (used in directory names and the CMake settings file).
+  # Required if `CMAKE_SETTINGS_DIR` is set.
   install:
     internal: true
     label: "{{.TASK}}:{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}-{{.EXTRA_ARGS}}"
@@ -152,8 +153,8 @@ tasks:
   # command.
   # @param {int} [CMAKE_JOBS] The maximum number of concurrent processes to use when building. If
   # omitted, the native build tool's default number is used. See `man cmake`.
-  # @param {string} [CMAKE_SETTINGS_DIR={{.WORK_DIR}}/cmake-settings] The directory where the
-  # project's CMake settings file should be stored.
+  # @param {string} [CMAKE_SETTINGS_DIR] The directory where the project's CMake settings file
+  # should be stored.
   # @param {string[]} [CMAKE_TARGETS] A list of specific targets to build instead of the default
   # target.
   install-remote-tar:

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -86,8 +86,8 @@ tasks:
 
   # Runs the CMake install step for the given build directory. The caller must have previously
   # called `build` on `BUILD_DIR` for this task to succeed. If `CMAKE_SETTINGS_DIR` is set, a
-  # settings file will be created in that directory, containing a `{{.NAME}}_ROOT` CMake variable
-  # that points to `INSTALL_PREFIX`.
+  # settings file will be created in that directory, containing a `{{.CMAKE_PACKAGE_NAME}}_ROOT`
+  # CMake variable that points to `INSTALL_PREFIX`.
   #
   # NOTE: We purposely omit `sources` and `generates` as we defer to `cmake` to decide whether it
   # should perform any actions.
@@ -97,8 +97,8 @@ tasks:
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
-  # @param {string} [NAME] CMake project name (used in directory names and the CMake settings file).
-  # Required if `CMAKE_SETTINGS_DIR` is set.
+  # @param {string} [CMAKE_PACKAGE_NAME] CMake project name (used in directory names and the CMake
+  # settings file).  Required if `CMAKE_SETTINGS_DIR` is set.
   install:
     internal: true
     label: "{{.TASK}}:{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}-{{.EXTRA_ARGS}}"
@@ -112,10 +112,10 @@ tasks:
     preconditions:
       - sh: >-
           {{if .CMAKE_SETTINGS_DIR}}
-            {{not (empty .NAME)}}
+            {{not (empty .CMAKE_PACKAGE_NAME)}}
           {{end}}
         msg: |-
-          NAME must be set if CMAKE_SETTINGS_DIR is set.
+          CMAKE_PACKAGE_NAME must be set if CMAKE_SETTINGS_DIR is set.
           CMAKE_SETTINGS_DIR: {{.CMAKE_SETTINGS_DIR}}
     cmds:
       - >-
@@ -127,11 +127,11 @@ tasks:
         {{- end}}
       - >-
         {{- if .CMAKE_SETTINGS_DIR}}
-          echo "set({{.NAME}}_ROOT
+          echo "set({{.CMAKE_PACKAGE_NAME}}_ROOT
             \"{{.INSTALL_PREFIX}}\"
             CACHE PATH
-            \"Package root for {{.NAME}}.\"
-          )" >> "{{.CMAKE_SETTINGS_DIR}}/{{.NAME}}.cmake"
+            \"Package root for {{.CMAKE_PACKAGE_NAME}}.\"
+          )" >> "{{.CMAKE_SETTINGS_DIR}}/{{.CMAKE_PACKAGE_NAME}}.cmake"
         {{- end}}
 
   # Downloads a CMake project tar file from `TAR_URL` and then generates, builds, and installs the
@@ -139,7 +139,7 @@ tasks:
   # should perform any actions. However, the download and extraction will be skipped if unnecessary.
   #
   # Required parameters
-  # @param {string} NAME CMake package name.
+  # @param {string} CMAKE_PACKAGE_NAME CMake package name.
   # @param {string} TAR_SHA256 Content hash to verify the downloaded tar file against.
   # @param {string} TAR_URL URL of the tar file to download.
   # @param {string} WORK_DIR Directory in which to store the build, install, and source directories.
@@ -159,7 +159,7 @@ tasks:
   # target.
   install-remote-tar:
     internal: true
-    label: "{{.TASK}}:{{.NAME}}-{{.TAR_URL}}-{{.INSTALL_PREFIX}}"
+    label: "{{.TASK}}:{{.CMAKE_PACKAGE_NAME}}-{{.TAR_URL}}-{{.INSTALL_PREFIX}}"
     vars:
       # CMake parameters
       CMAKE_BUILD_ARGS:
@@ -176,12 +176,12 @@ tasks:
         ref: "default (list) .CMAKE_TARGETS"
 
       # Directory parameters
-      BUILD_DIR: "{{.WORK_DIR}}/{{.NAME}}-build"
-      INSTALL_PREFIX: "{{.WORK_DIR}}/{{.NAME}}-install"
-      SOURCE_DIR: "{{.WORK_DIR}}/{{.NAME}}-src"
+      BUILD_DIR: "{{.WORK_DIR}}/{{.CMAKE_PACKAGE_NAME}}-build"
+      INSTALL_PREFIX: "{{.WORK_DIR}}/{{.CMAKE_PACKAGE_NAME}}-install"
+      SOURCE_DIR: "{{.WORK_DIR}}/{{.CMAKE_PACKAGE_NAME}}-src"
 
     requires:
-      vars: ["NAME", "TAR_SHA256", "TAR_URL", "WORK_DIR"]
+      vars: ["CMAKE_PACKAGE_NAME", "TAR_SHA256", "TAR_URL", "WORK_DIR"]
     deps:
       - task: "remote:download-and-extract-tar"
         vars:
@@ -210,7 +210,7 @@ tasks:
           EXTRA_ARGS:
             ref: ".CMAKE_INSTALL_ARGS"
           INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
-          NAME: "{{.NAME}}"
+          CMAKE_PACKAGE_NAME: "{{.CMAKE_PACKAGE_NAME}}"
 
   # Sets up all CMake dependencies for a project by:
   #

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -94,10 +94,10 @@ tasks:
   #
   # @param {string} BUILD_DIR Directory containing the completed build to use.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
-  # @param {string} NAME CMake project name (used in directory names and the CMake settings file).
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
+  # @param {string} [NAME] CMake project name (used in directory names and the CMake settings file).
   install:
     internal: true
     label: "{{.TASK}}:{{.BUILD_DIR}}-{{.INSTALL_PREFIX}}-{{.EXTRA_ARGS}}"
@@ -107,7 +107,15 @@ tasks:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
     requires:
-      vars: ["BUILD_DIR", "INSTALL_PREFIX", "NAME"]
+      vars: ["BUILD_DIR", "INSTALL_PREFIX"]
+    preconditions:
+      - sh: >-
+          {{if .CMAKE_SETTINGS_DIR}}
+            {{not (empty .NAME)}}
+          {{end}}
+        msg: |-
+          NAME must be set if CMAKE_SETTINGS_DIR is set.
+          CMAKE_SETTINGS_DIR: {{.CMAKE_SETTINGS_DIR}}
     cmds:
       - >-
         cmake
@@ -162,7 +170,7 @@ tasks:
       CMAKE_JOBS: >-
         {{default "" .CMAKE_JOBS}}
       CMAKE_SETTINGS_DIR: >-
-        {{default (printf "%s/cmake-settings" .WORK_DIR) .CMAKE_SETTINGS_DIR}}
+        {{default "" .CMAKE_SETTINGS_DIR}}
       CMAKE_TARGETS:
         ref: "default (list) .CMAKE_TARGETS"
 


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

As title says.
Additional minor changes:
* `NAME` is renamed to `CMAKE_PACKAGE_NAME` to avoid issues with WSL where the `NAME` environment variable is set by default.
* `CMAKE_SETTINGS_DIR` no longer has a default value in `utils:cmake:install-remote-tar` to ensure it is set explicitly and intentionally.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Tested locally with log-surgeon.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Documentation**
  - Updated parameter documentation to rename `NAME` to `CMAKE_PACKAGE_NAME` and clarify its requirement when `CMAKE_SETTINGS_DIR` is set.

- **New Features**
  - Added a conditional check requiring `CMAKE_PACKAGE_NAME` only when `CMAKE_SETTINGS_DIR` is specified.

- **Chores**
  - Adjusted default values and validation logic for install-related parameters to improve flexibility and unify naming conventions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->