### PR TITLE
fix: Use separate directory for boost source and build (fixes #63).

### DIFF
--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -7,22 +7,34 @@ set: ["u", "pipefail"]
 shopt: ["globstar"]
 
 tasks:
-  # Runs the bootstrap.sh generate step in the given source directory. Boost only supports
-  # in-source generation and building.
+  # Creates a build directory that soft links the source files from `SOURCE_DIR`. Runs
+  # `bootstrap.sh` to generate the `b2` build tool and `project-config.jam` file in the build
+  # directory.
   #
   # @param {string} SOURCE_DIR Project source directory.
+  # @param {string} BUILD_DIR Directory in which to build the project.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string[]} TARGETS Target libraries to build.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the generate command.
   generate:
     internal: true
-    dir: "{{.SOURCE_DIR}}"
+    dir: "{{.BUILD_DIR}}"
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
     requires:
-      vars: ["SOURCE_DIR", "INSTALL_PREFIX", "TARGETS"]
+      vars: ["SOURCE_DIR", "BUILD_DIR", "INSTALL_PREFIX", "TARGETS"]
+    generates:
+      - "{{.BUILD_DIR}}/b2"
+      - "{{.BUILD_DIR}}/project-config.jam"
     cmds:
+      - |
+        for file in "{{.SOURCE_DIR}}"/*; do
+          filename=$(basename "$file")
+          target="{{.BUILD_DIR}}"/"$filename"
+          [ -e "$target" ] && continue
+          ln -s "$file" "$target"
+        done
       - >-
         ./bootstrap.sh
         --prefix="{{.INSTALL_PREFIX}}"
@@ -33,23 +45,23 @@ tasks:
         {{- end}}
 
   # Runs the b2 build step for boost. The caller must have previously called `generate` on
-  # `SOURCE_DIR` for this task to succeed.
+  # `BUILD_DIR` for this task to succeed.
   #
-  # @param {string} SOURCE_DIR Directory containing the boost source.
+  # @param {string} BUILD_DIR Directory containing the boost source.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
   # omitted, the b2 default number is used. Before 1.76.0, the number was 1. Since 1.76.0, the
   # default is the number of cores.
   build:
     internal: true
-    dir: "{{.SOURCE_DIR}}"
+    dir: "{{.BUILD_DIR}}"
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
       JOBS: >-
         {{default "" .JOBS}}
     requires:
-      vars: ["SOURCE_DIR"]
+      vars: ["BUILD_DIR"]
     cmds:
       - >-
         ./b2
@@ -61,18 +73,18 @@ tasks:
         {{- end}}
 
   # Runs the b2 install step for boost. The caller must have previously called `build` on
-  # `SOURCE_DIR` for this task to succeed. If `CMAKE_SETTINGS_DIR` is set, a settings file will be
+  # `BUILD_DIR` for this task to succeed. If `CMAKE_SETTINGS_DIR` is set, a settings file will be
   # created in that directory, containing a `boost_ROOT` CMake variable that points to
   # `INSTALL_PREFIX`.
   #
-  # @param {string} SOURCE_DIR Directory containing the boost source.
+  # @param {string} BUILD_DIR Directory containing the boost source.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the install command.
   install:
     internal: true
-    dir: "{{.SOURCE_DIR}}"
+    dir: "{{.BUILD_DIR}}"
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
@@ -81,7 +93,7 @@ tasks:
       CMAKE_SETTINGS_DIR: >-
         {{default "" .CMAKE_SETTINGS_DIR}}
     requires:
-      vars: ["SOURCE_DIR", "INSTALL_PREFIX"]
+      vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     cmds:
       - >-
         ./b2
@@ -97,13 +109,15 @@ tasks:
             \"Package root for boost.\"
           )" >> "{{.CMAKE_SETTINGS_DIR}}/boost.cmake"
         {{- end}}
+
   # Downloads boost from `URL` and installs boost.
   #
   # General parameters
-  # @param {string} [WORK_DIR={{.ROOT_DIR}}] Base directory to store the install and src
+  # @param {string} [WORK_DIR={{.ROOT_DIR}}] Base directory to store the src, build and install
   # directories inside.
   # @param {string} [SOURCE_DIR={{.WORK_DIR}}/boost-src] Directory in which to extract the tar
   # file.
+  # @param {string} [BUILD_DIR={{.WORK_DIR}}/boost-build] Directory in which to build the project.
   #
   # Download parameters
   # @param {string} FILE_SHA256 Content hash to verify the downloaded tar file against.
@@ -134,6 +148,8 @@ tasks:
         {{default .ROOT_DIR .WORK_DIR}}
       SOURCE_DIR: >-
         {{default (printf "%s/boost-src" .WORK_DIR) .SOURCE_DIR}}
+      BUILD_DIR: >-
+        {{default (printf "%s/boost-build" .WORK_DIR) .BUILD_DIR}}
 
       # Boost generate parameters
       INSTALL_PREFIX: >-
@@ -163,9 +179,12 @@ tasks:
           OUTPUT_DIR: "{{.SOURCE_DIR}}"
           URL: "{{.URL}}"
     cmds:
+      - >-
+        mkdir -p "{{.BUILD_DIR}}"
       - task: "generate"
         vars:
           SOURCE_DIR: "{{.SOURCE_DIR}}"
+          BUILD_DIR: "{{.BUILD_DIR}}"
           INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
           TARGETS:
             ref: ".TARGETS"
@@ -173,13 +192,13 @@ tasks:
             ref: ".GEN_ARGS"
       - task: "build"
         vars:
-          SOURCE_DIR: "{{.SOURCE_DIR}}"
+          BUILD_DIR: "{{.BUILD_DIR}}"
           JOBS: "{{.JOBS}}"
           EXTRA_ARGS:
             ref: ".BUILD_ARGS"
       - task: "install"
         vars:
-          SOURCE_DIR: "{{.SOURCE_DIR}}"
+          BUILD_DIR: "{{.BUILD_DIR}}"
           INSTALL_PREFIX: "{{.INSTALL_PREFIX}}"
           CMAKE_SETTINGS_DIR: "{{.CMAKE_SETTINGS_DIR}}"
           EXTRA_ARGS:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Boost is built in-source, so the second time `boost:download-and-install` is called, the source directory changes and must be downloaded again, and the previous build is lost.
This PR solves this problem by using a separate build directory that soft links every file in the source directory and leave the source directory untouched. This solves the problem of re-download and rebuild.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed
Run `task tests:boost` twice and no download and rebuild is executed the second time.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
