### PR TITLE
fix(taskfiles): Add missing venv activation to utils:clang-format.

### DIFF
--- a/exports/taskfiles/utils/cpp-lint.yaml
+++ b/exports/taskfiles/utils/cpp-lint.yaml
@@ -39,7 +39,7 @@ tasks:
       vars: ["ROOT_PATHS", "VENV_DIR"]
 
     cmd: |-
-      . "{{.VENV_DIR}}/bin/activate" \
+      . "{{.VENV_DIR}}/bin/activate"
       uv run --project "{{.TASKFILE_DIR}}/../../ystdlib-py" pyfind \
         {{- range .ROOT_PATHS}}
           "{{.}}" \


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

As title says. PR #59 removed the virtual environment activate call for the clang-format task. This can lead to the task to use the wrong version of clang-format.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tested locally and through https://github.com/y-scope/ystdlib-cpp/actions/runs/15579797403/job/43872171830?pr=65.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated the clang-format task to ensure the Python virtual environment is activated before running related commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->