### PR TITLE
fix(taskfiles)!: Remove quotes when evaluating EXTRA_ARGS in CMake tasks, properly treating them as command flags.

### DIFF
--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -37,7 +37,7 @@ tasks:
         --target="{{.}}"
         {{- end}}
         {{- range .EXTRA_ARGS}}
-        "{{.}}"
+        {{.}}
         {{- end}}
 
   # Runs the CMake clean target for the given build directory. The caller must have previously
@@ -81,7 +81,7 @@ tasks:
         -S "{{.SOURCE_DIR}}"
         -B "{{.BUILD_DIR}}"
         {{- range .EXTRA_ARGS}}
-        "{{.}}"
+        {{.}}
         {{- end}}
 
   # Runs the CMake install step for the given build directory. The caller must have previously

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -123,7 +123,7 @@ tasks:
         --install "{{.BUILD_DIR}}"
         --prefix "{{.INSTALL_PREFIX}}"
         {{- range .EXTRA_ARGS}}
-        "{{.}}"
+        {{.}}
         {{- end}}
       - >-
         {{- if .CMAKE_SETTINGS_DIR}}

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -107,8 +107,6 @@ tasks:
         {{default "" .CMAKE_SETTINGS_DIR}}
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      COMPONENT: >-
-        {{default "" .COMPONENT}}
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     preconditions:
@@ -124,7 +122,6 @@ tasks:
         cmake
         --install "{{.BUILD_DIR}}"
         --prefix "{{.INSTALL_PREFIX}}"
-        {{if not (eq .COMPONENT "")}}--component {{.COMPONENT}}{{end}}
         {{- range .EXTRA_ARGS}}
         {{.}}
         {{- end}}

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -107,6 +107,8 @@ tasks:
         {{default "" .CMAKE_SETTINGS_DIR}}
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
+      COMPONENT: >-
+        {{default "" .COMPONENT}}
     requires:
       vars: ["BUILD_DIR", "INSTALL_PREFIX"]
     preconditions:
@@ -122,6 +124,7 @@ tasks:
         cmake
         --install "{{.BUILD_DIR}}"
         --prefix "{{.INSTALL_PREFIX}}"
+        {{if not (eq .COMPONENT "")}}--component {{.COMPONENT}}{{end}}
         {{- range .EXTRA_ARGS}}
         {{.}}
         {{- end}}


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
An empty string passed in EXTRA_ARGS throws an error in the previous version. This is undesirable for conditional extra arguments passed to cmake:install.


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Ran linters and tests.


[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of extra arguments in the install process to ensure correct command-line parsing.
- **New Features**
  - Added support for specifying installation components to customize the install process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->