### PR TITLE
fix(taskfiles)!: Check the specified `FILE_SHA256` matches the downloaded file in `remote:curl`.

### DIFF
--- a/exports/taskfiles/utils/remote.yaml
+++ b/exports/taskfiles/utils/remote.yaml
@@ -21,9 +21,9 @@ tasks:
       vars: ["FILE_SHA256", "URL"]
     generates: ["{{.OUTPUT_FILE}}"]
     status:
-      - >-
-        diff
-          <(echo "{{.FILE_SHA256}}")
+      - |-
+        diff \
+          <(echo "{{.FILE_SHA256}}") \
           <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
     cmds:
       - |-

--- a/exports/taskfiles/utils/remote.yaml
+++ b/exports/taskfiles/utils/remote.yaml
@@ -23,9 +23,8 @@ tasks:
     status:
       - >-
         diff
-        <(echo "{{.FILE_SHA256}}")
-        <(openssl dgst -sha256 "{{.OUTPUT_FILE}}"
-        | awk '{print $2}')
+          <(echo "{{.FILE_SHA256}}")
+          <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
     cmds:
       - |-
         mkdir -p "{{dir .OUTPUT_FILE}}"
@@ -50,6 +49,9 @@ tasks:
           echo "Failed to download after $max_attempts attempts."
           exit 1
         fi
+        diff \
+          <(echo "{{.FILE_SHA256}}") \
+          <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
 
   # Uses curl to download a tar file from the given URL and extracts its contents.
   #

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -48,7 +48,7 @@ tasks:
     vars:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
       OUTPUT_FILE: "{{.OUTPUT_DIR}}.zip"
-      OUTPUT_FILE_MOD_TS: "{{.CHECKSUM_FILE}}-mod-ts.txt"
+      OUTPUT_FILE_MOD_TS: "{{.OUTPUT_FILE}}-mod-ts.txt"
     cmds:
       - task: "remote-test-cleaner"
         vars:

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -4,13 +4,17 @@ includes:
   remote: "../../exports/taskfiles/utils/remote.yaml"
 
 vars:
-  G_EXTRACTED_ROOT_DIR: "yscope-dev-utils-fd7c42dd7b59f8f4ab0eccba5078393e10cddb00"
-  G_EXTRACTED_ZIP_CODEOWNERS_PATH: "{{.G_EXTRACTED_ROOT_DIR}}/.github/CODEOWNERS"
-  G_EXTRACTED_ZIP_LICENSE_PATH: "{{.G_EXTRACTED_ROOT_DIR}}/LICENSE"
-  G_EXTRACTED_ZIP_PULL_REQUEST_TEMPLATE_PATH: >-
-    {{.G_EXTRACTED_ROOT_DIR}}/.github/PULL_REQUEST_TEMPLATE.md
+  # Test zip file info
+  G_TEST_COMMIT_HASH: "fd7c42dd7b59f8f4ab0eccba5078393e10cddb00"
   G_TEST_ZIP_FILE_SHA256: "141e807e9b4b9e28c254165c5a402ff54c0c9d3f9153178dfcff5354ace0c3d4"
-  G_TEST_ZIP_FILE_URL: "https://github.com/y-scope/yscope-dev-utils/archive/fd7c42d.zip"
+  G_TEST_ZIP_FILE_URL: "https://github.com/y-scope/yscope-dev-utils/archive/{{.G_TEST_COMMIT_HASH}}.zip"
+
+  # Extracted test zip file contents
+  G_EXTRACTED_ZIP_DIR: "yscope-dev-utils-{{.G_TEST_COMMIT_HASH}}"
+  G_EXTRACTED_ZIP_CODEOWNERS_PATH: "{{.G_EXTRACTED_ZIP_DIR}}/.github/CODEOWNERS"
+  G_EXTRACTED_ZIP_LICENSE_PATH: "{{.G_EXTRACTED_ZIP_DIR}}/LICENSE"
+  G_EXTRACTED_ZIP_PULL_REQUEST_TEMPLATE_PATH: >-
+    {{.G_EXTRACTED_ZIP_DIR}}/.github/PULL_REQUEST_TEMPLATE.md
 
 tasks:
   default:

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -22,6 +22,7 @@ tasks:
     internal: true
     cmds:
       - task: "curl-test-success"
+      - task: "curl-test-success-skip"
       - task: "download-and-extract-zip-test-basic"
       - task: "download-and-extract-zip-test-exclusions"
       - task: "download-and-extract-zip-test-inclusions"

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -30,6 +30,9 @@ tasks:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
       OUTPUT_FILE: "{{.OUTPUT_DIR}}.zip"
     cmds:
+      - task: "remote-test-cleaner"
+        vars:
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
       - task: "remote:curl"
         vars:
           FILE_SHA256: "{{.G_TEST_ZIP_FILE_SHA256}}"
@@ -40,11 +43,37 @@ tasks:
           <(echo "{{.G_TEST_ZIP_FILE_SHA256}}") \
           <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
 
+  curl-test-success-skip:
+    vars:
+      OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_DIR}}.zip"
+      OUTPUT_FILE_MOD_TS: "{{.CHECKSUM_FILE}}-mod-ts.txt"
+    cmds:
+      - task: "remote-test-cleaner"
+        vars:
+          OUTPUT_DIR: "{{.OUTPUT_DIR}}"
+      - task: "remote:curl"
+        vars:
+          FILE_SHA256: "{{.G_TEST_ZIP_FILE_SHA256}}"
+          OUTPUT_FILE: "{{.OUTPUT_FILE}}"
+          URL: "{{.G_TEST_ZIP_FILE_URL}}"
+      - "date -r '{{.OUTPUT_FILE}}' > '{{.OUTPUT_FILE_MOD_TS}}'"
+      - task: "remote:curl"
+        vars:
+          FILE_SHA256: "{{.G_TEST_ZIP_FILE_SHA256}}"
+          OUTPUT_FILE: "{{.OUTPUT_FILE}}"
+          URL: "{{.G_TEST_ZIP_FILE_URL}}"
+      - |-
+        diff \
+          <(echo "{{.G_TEST_ZIP_FILE_SHA256}}") \
+          <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
+      - "diff '{{.OUTPUT_FILE_MOD_TS}}' <(date -r '{{.OUTPUT_FILE}}')"
+
   download-and-extract-zip-test-basic:
     vars:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
     cmds:
-      - task: "download-and-extract-zip-test-cleaner"
+      - task: "remote-test-cleaner"
         vars:
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
       - task: "remote:download-and-extract-zip"
@@ -64,7 +93,7 @@ tasks:
     vars:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
     cmds:
-      - task: "download-and-extract-zip-test-cleaner"
+      - task: "remote-test-cleaner"
         vars:
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
       - task: "remote:download-and-extract-zip"
@@ -87,7 +116,7 @@ tasks:
     vars:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
     cmds:
-      - task: "download-and-extract-zip-test-cleaner"
+      - task: "remote-test-cleaner"
         vars:
           OUTPUT_DIR: "{{.OUTPUT_DIR}}"
       - task: "remote:download-and-extract-zip"
@@ -104,11 +133,10 @@ tasks:
       - "test -e '{{.OUTPUT_DIR}}/{{.G_EXTRACTED_ZIP_CODEOWNERS_PATH}}'"
       - "test -e '{{.OUTPUT_DIR}}/{{.G_EXTRACTED_ZIP_PULL_REQUEST_TEMPLATE_PATH}}'"
 
-  # Cleans up the files output by download-and-extract-zip (assuming their default paths weren't
-  # changed).
+  # Cleans up the files output by remote tasks (assuming their default paths weren't changed).
   #
-  # @param {string} OUTPUT_DIR Output directory passed to download-and-extract-zip.
-  download-and-extract-zip-test-cleaner:
+  # @param {string} OUTPUT_DIR Output directory passed to remote tasks.
+  remote-test-cleaner:
     internal: true
     requires:
       vars: ["OUTPUT_DIR"]

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -45,6 +45,8 @@ tasks:
           <(echo "{{.G_TEST_ZIP_FILE_SHA256}}") \
           <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
 
+  # Tests that re-running the curl task won't re-download the file if it already exists and matches
+  # the expected checksum.
   curl-test-success-skip:
     vars:
       OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -4,20 +4,37 @@ includes:
   remote: "../../exports/taskfiles/utils/remote.yaml"
 
 vars:
-  G_EXTRACTED_ZIP_CODEOWNERS_PATH: "yscope-dev-utils-main/.github/CODEOWNERS"
-  G_EXTRACTED_ZIP_LICENSE_PATH: "yscope-dev-utils-main/LICENSE"
+  G_EXTRACTED_ROOT_DIR: "yscope-dev-utils-fd7c42dd7b59f8f4ab0eccba5078393e10cddb00"
+  G_EXTRACTED_ZIP_CODEOWNERS_PATH: "{{.G_EXTRACTED_ROOT_DIR}}/.github/CODEOWNERS"
+  G_EXTRACTED_ZIP_LICENSE_PATH: "{{.G_EXTRACTED_ROOT_DIR}}/LICENSE"
   G_EXTRACTED_ZIP_PULL_REQUEST_TEMPLATE_PATH: >-
-    yscope-dev-utils-main/.github/PULL_REQUEST_TEMPLATE.md
-  G_TEST_ZIP_FILE_SHA256: "2c9a21f83484e004c41c28be759451dbdc787190eb044365ba58f7bb846418f6"
-  G_TEST_ZIP_FILE_URL: "https://github.com/y-scope/yscope-dev-utils/archive/refs/heads/main.zip"
+    {{.G_EXTRACTED_ROOT_DIR}}/.github/PULL_REQUEST_TEMPLATE.md
+  G_TEST_ZIP_FILE_SHA256: "141e807e9b4b9e28c254165c5a402ff54c0c9d3f9153178dfcff5354ace0c3d4"
+  G_TEST_ZIP_FILE_URL: "https://github.com/y-scope/yscope-dev-utils/archive/fd7c42d.zip"
 
 tasks:
   default:
     internal: true
     cmds:
+      - task: "curl-test-success"
       - task: "download-and-extract-zip-test-basic"
       - task: "download-and-extract-zip-test-exclusions"
       - task: "download-and-extract-zip-test-inclusions"
+
+  curl-test-success:
+    vars:
+      OUTPUT_DIR: "{{.G_OUTPUT_DIR}}/{{.TASK | replace \":\" \"#\"}}"
+      OUTPUT_FILE: "{{.OUTPUT_DIR}}.zip"
+    cmds:
+      - task: "remote:curl"
+        vars:
+          FILE_SHA256: "{{.G_TEST_ZIP_FILE_SHA256}}"
+          OUTPUT_FILE: "{{.OUTPUT_FILE}}"
+          URL: "{{.G_TEST_ZIP_FILE_URL}}"
+      - |-
+        diff \
+          <(echo "{{.G_TEST_ZIP_FILE_SHA256}}") \
+          <(openssl dgst -sha256 "{{.OUTPUT_FILE}}" | awk '{print $2}')
 
   download-and-extract-zip-test-basic:
     vars:

--- a/taskfiles/remote/tests.yaml
+++ b/taskfiles/remote/tests.yaml
@@ -7,7 +7,8 @@ vars:
   # Test zip file info
   G_TEST_COMMIT_HASH: "fd7c42dd7b59f8f4ab0eccba5078393e10cddb00"
   G_TEST_ZIP_FILE_SHA256: "141e807e9b4b9e28c254165c5a402ff54c0c9d3f9153178dfcff5354ace0c3d4"
-  G_TEST_ZIP_FILE_URL: "https://github.com/y-scope/yscope-dev-utils/archive/{{.G_TEST_COMMIT_HASH}}.zip"
+  G_TEST_ZIP_FILE_URL: >-
+    https://github.com/y-scope/yscope-dev-utils/archive/{{.G_TEST_COMMIT_HASH}}.zip
 
   # Extracted test zip file contents
   G_EXTRACTED_ZIP_DIR: "yscope-dev-utils-{{.G_TEST_COMMIT_HASH}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

As originally pointed out in #24, the `remote:curl` task does not check that the provided `FILE_SHA256` argument matches what was downloaded (it only used it to check whether the file already existed).
This PR:
1. Adds a SHA check to the end of `remote:curl`.
2. Adds two unit test= for `remote:curl`.
    1. Test successful download.
    2. Test skipping download in a repeated run after a successful download.
4. Switches `G_TEST_ZIP_FILE_URL` to use a specific commit rather than `main` so that `G_TEST_ZIP_FILE_SHA256` is correct.
    * This avoids the need to update `G_TEST_ZIP_FILE_SHA256` with every change to `main`.



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

* Tested locally.
* CI passing.
* Unit tests passing.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added tests to verify download success and file integrity using SHA256 checksum verification.
  * Introduced a test to confirm idempotent downloads by checking file modification timestamps.
* **Chores**
  * Updated test configurations to use a commit-specific zip archive and unified extracted directory variables.
  * Renamed and generalized cleanup tasks for better test maintenance.
* **Bug Fixes**
  * Added post-download SHA256 hash verification to ensure file integrity immediately after download.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->