### PR TITLE
feat: Add CMAKE_SOURCE_DIR variable to install-remote-tar task.

### DIFF
--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -157,6 +157,8 @@ tasks:
   # should be stored.
   # @param {string[]} [CMAKE_TARGETS] A list of specific targets to build instead of the default
   # target.
+  # @param {string} [CMAKE_SOURCE_DIR] Optional path, relative to SRC_DIR, specifying a custom
+  # CMake source directory to pass to the CMake generate command.
   install-remote-tar:
     internal: true
     label: "{{.TASK}}:{{.CMAKE_PACKAGE_NAME}}-{{.TAR_URL}}-{{.INSTALL_PREFIX}}"
@@ -174,6 +176,8 @@ tasks:
         {{default "" .CMAKE_SETTINGS_DIR}}
       CMAKE_TARGETS:
         ref: "default (list) .CMAKE_TARGETS"
+      CMAKE_SOURCE_DIR: >-
+        {{default "." .CMAKE_SOURCE_DIR}}
 
       # Directory parameters
       BUILD_DIR: "{{.WORK_DIR}}/{{.CMAKE_PACKAGE_NAME}}-build"
@@ -194,7 +198,7 @@ tasks:
           BUILD_DIR: "{{.BUILD_DIR}}"
           EXTRA_ARGS:
             ref: ".CMAKE_GEN_ARGS"
-          SOURCE_DIR: "{{.SOURCE_DIR}}"
+          SOURCE_DIR: "{{.SOURCE_DIR}}/{{.CMAKE_SOURCE_DIR}}"
       - task: "build"
         vars:
           BUILD_DIR: "{{.BUILD_DIR}}"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description
This PR introduces foundational low-level functionality to support a broader initiative: migrating the libarchive dependency to be downloaded and compiled via task, pinned to a secure version across all platforms. For the transitive dependencies `zstd` and `lz4`, the CMake source directory is located at `<project root>/build/cmake`. These changes are essential for enabling robust, platform-consistent behavior in the CLP repository’s task files

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Validation was performed by compiling libarchive along with all its transitive dependencies—lz4, xz, zlib, and zstd—using the functionality introduced in this PR.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
