### PR TITLE
ci(boost): Remove timeout from boost::process unit test to avoid errors in slow CI runs.

### DIFF
--- a/taskfiles/boost/test_boost.cpp
+++ b/taskfiles/boost/test_boost.cpp
@@ -97,7 +97,6 @@ auto test_iostreams() -> bool {
 }
 
 auto test_process() -> bool {
-    constexpr int cWaitTime = 10;
     try {
         boost::asio::io_context io_context;
         boost::process::v2::process process{
@@ -107,10 +106,8 @@ auto test_process() -> bool {
                 boost::process::process_stdio{.in{}, .out{nullptr}, .err{nullptr}}
         };
         std::future<int> result = process.async_wait(boost::asio::use_future);
-        io_context.run_for(std::chrono::milliseconds(cWaitTime));
-        if (std::future_status::ready != result.wait_for(std::chrono::milliseconds(cWaitTime))) {
-            return false;
-        }
+        io_context.run();
+        result.wait();
         return 0 == result.get();
     } catch (std::exception const& e) {
         return false;


### PR DESCRIPTION

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

Previously, the boost::process unit test used a timeout of 10ms when running an async process. This timeout seems to occasionally cause failures on macos-15 runners.

Examples:
* [the PR that added macos-15 CI](https://github.com/y-scope/yscope-dev-utils/pull/71) has passing CI runs: https://github.com/y-scope/yscope-dev-utils/actions/runs/16303492402/job/46043785491
* scheduled CI failed: https://github.com/y-scope/yscope-dev-utils/actions/runs/16308884279/job/46062965426


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
