### PR TITLE
fix(taskfiles)!: Normalize `splitList` output with `compact` for reliable list iteration (fixes #59).

### DIFF
--- a/exports/taskfiles/utils/cpp-lint.yaml
+++ b/exports/taskfiles/utils/cpp-lint.yaml
@@ -200,7 +200,7 @@ tasks:
             {{- end}}
       SOURCE_FILE_PATHS:
         ref: >-
-          splitList "\n" .SOURCE_FILE_PATHS_
+          compact (splitList "\n" .SOURCE_FILE_PATHS_)
     requires:
       vars: ["ROOT_PATHS", "VENV_DIR"]
     cmds:


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This change wraps `splitList` with `compact` when generating `SOURCE_FILE_PATHS` list in task `clang-tidy-find`. Without this wrap to remove potentially blank list entries, the for loop in task `clang-tidy-parallel` will fail with `loop var must be a delimiter-separated string, list or a map`.  

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Tested with CLP repo workflows.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when processing source file paths by ensuring empty entries are filtered out during linting tasks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->