### PR TITLE
feat(lint-configs): Disable clang-tidy's `modernize-use-ranges` check since we need to build with compilers that don't support ranges.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -9,6 +9,7 @@ WarningsAsErrors: >-
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
+# - `modernize-use-ranges` because we want to support compilations with llvm/apple clang 15.
 # - `portability-template-virtual-member-function` because we don't support MSVC compilers yet.
 # - `readability-identifier-length` because it's case-dependent.
 # - `readability-named-parameter` because we don't want to enforce that all parameters have a name.
@@ -24,6 +25,7 @@ Checks: >-
   cppcoreguidelines-*,
   misc-*,
   modernize-*,
+  -modernize-use-ranges,
   performance-*,
   portability-*,
   -portability-template-virtual-member-function,

--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -9,7 +9,8 @@ WarningsAsErrors: >-
 
 # Disabled checks:
 # - `bugprone-easily-swappable-parameters` because it's difficult to mitigate.
-# - `modernize-use-ranges` because we want to support compilations with llvm/apple clang 15.
+# - `modernize-use-ranges` because we want to support compiling C++20 code with LLVM/Apple Clang 15,
+#   but those compiler versions don't support ranges.
 # - `portability-template-virtual-member-function` because we don't support MSVC compilers yet.
 # - `readability-identifier-length` because it's case-dependent.
 # - `readability-named-parameter` because we don't want to enforce that all parameters have a name.


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

To align with the lowered minimum compiler requirement (Clang 15) for Velox compatibility, we are disabling the `modernize-use-ranges` check in clang-tidy. This check enforces use of `std::ranges`, which is [not fully supported](https://stackoverflow.com/questions/73929080/error-with-clang-15-and-c20-stdviewsfilter) in Clang 15.

See also: https://github.com/y-scope/ystdlib-cpp/pull/72


# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Nothing to be tested.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.
- Chores
  - Updated static analysis settings to disable a noisy modernisation rule, reducing false positives and streamlining reviews.
- Documentation
  - Added an explanatory note about the rationale for disabling the rule to help maintainers.

No impact on performance or functionality; existing behaviour unchanged. Estimated review effort: Low.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->