### PR TITLE
feat(lint-configs): Update the clang-format config for clang-format v21.

### DIFF
--- a/exports/lint-configs/.clang-format
+++ b/exports/lint-configs/.clang-format
@@ -19,7 +19,7 @@ AlignTrailingComments:
 AllowAllArgumentsOnNextLine: false
 AllowAllParametersOfDeclarationOnNextLine: false
 AllowBreakBeforeNoexceptSpecifier: "OnlyWithParen"
-AllowShortBlocksOnASingleLine: "Always"
+AllowShortBlocksOnASingleLine: "Empty"
 AllowShortCaseLabelsOnASingleLine: false
 AllowShortCompoundRequirementOnASingleLine: true
 AllowShortEnumsOnASingleLine: false
@@ -30,6 +30,7 @@ AllowShortLoopsOnASingleLine: false
 AllowShortNamespacesOnASingleLine: false
 AlwaysBreakBeforeMultilineStrings: false
 BinPackArguments: false
+BinPackLongBracedList: false
 BinPackParameters: false
 BitFieldColonSpacing: "Both"
 BraceWrapping:
@@ -56,6 +57,7 @@ BreakBeforeBinaryOperators: "All"
 BreakBeforeBraces: "Custom"
 BreakBeforeConceptDeclarations: "Always"
 BreakBeforeInlineASMColon: "OnlyMultiline"
+BreakBeforeTemplateCloser: false
 BreakBeforeTernaryOperators: true
 BreakBinaryOperations: "Never"
 BreakConstructorInitializers: "BeforeColon"
@@ -71,6 +73,7 @@ DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineAfterAccessModifier: "Never"
 EmptyLineBeforeAccessModifier: "LogicalBlock"
+EnumTrailingComma: Leave
 FixNamespaceComments: true
 IncludeBlocks: "Regroup"
 IndentAccessModifiers: false
@@ -101,6 +104,7 @@ LineEnding: "LF"
 MainIncludeChar: "Quote"
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: "None"
+OneLineFormatOffRegex: "^// NOLINT"
 PPIndentWidth: -1
 PackConstructorInitializers: "CurrentLine"
 PenaltyBreakOpenParenthesis: 25
@@ -130,6 +134,7 @@ SortIncludes: "CaseInsensitive"
 SortUsingDeclarations: "Lexicographic"
 SpaceAfterCStyleCast: false
 SpaceAfterLogicalNot: false
+SpaceAfterOperatorKeyword: false
 SpaceAfterTemplateKeyword: true
 SpaceAroundPointerQualifiers: "Default"
 SpaceBeforeAssignmentOperators: true

--- a/exports/lint-configs/.clang-format
+++ b/exports/lint-configs/.clang-format
@@ -73,7 +73,7 @@ DerivePointerAlignment: false
 DisableFormat: false
 EmptyLineAfterAccessModifier: "Never"
 EmptyLineBeforeAccessModifier: "LogicalBlock"
-EnumTrailingComma: Leave
+EnumTrailingComma: "Leave"
 FixNamespaceComments: true
 IncludeBlocks: "Regroup"
 IndentAccessModifiers: false


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
This PR updates the clang-format config to adapt release v21. Changes:
* `AllowShortBlocksOnASingleLine`: Set to `Empty` as clang-format v21 is more aggressive when the value is set to `Always`.
* `BinPackLongBracedList`: Set to `false` so that long initializer list have one element per line.
* `BreakBeforeTemplateCloser`: Set to `false` so the closing bracket `>` of a template does not occupy a line alone.
* `EnumTrailingComma`: Set to `Leave` as the other values could leave to incorrect code formatting.
* `OneLineFormatOffRegex`: Set to `^// NOLINT` as a good default value for skipping format. Not setting it also works.
* `SpaceAfterOperatorKeyword`: Set to `false` to avoid space after keyword `operator`.

The following options are not added:
* `MacrosSkippedByRemoveParentheses`: This should be a project-specific option.

Ref:
clang-format v21.1.0 release note: https://releases.llvm.org/21.1.0/tools/clang/docs/ReleaseNotes.html#clang-format
clang-format v21.1.0 doc: https://releases.llvm.org/21.1.0/tools/clang/docs/ClangFormatStyleOptions.html



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
* [x] Using the updated config locally on spider to ensure spider can be correctly formatted.
* [x] `lint:check-yaml` passes.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html
