### PR TITLE
feat(lint-configs): Disable some `ruff` rules to allow practices we deem acceptable; Disable some `ruff` rules for tests.

### DIFF
--- a/exports/lint-configs/python/ruff.toml
+++ b/exports/lint-configs/python/ruff.toml
@@ -3,6 +3,7 @@ line-length = 100
 [lint]
 select = ["ALL"]
 ignore = [
+    "ANN401", # Allow using Any type for function signatures
     "COM812",  # Redundant and conflicts with ruff format
     "D203",  # No blank line before docstrings (D211)
     "D205",  # Breaks if summary is larger than one line due to wrapping or if no summary exists
@@ -15,12 +16,20 @@ ignore = [
     "PERF401",  # Allow for loops when creating lists
     "PERF403",  # Allow for loops when creating dicts
     "S311",  # Allow usage of `random` package
+    "S603", # Automatically trust inputs of subprocess execution
     "SIM102",  # Allow collapsible if statements for readability
+    "SIM300", # Skip Yoda-condition format fixes
     "TD002",  # Author unnecessary for todo statement
     "TD003",  # Issue link unnecessary for todo statement
     "UP015",  # Explicit open modes are helpful
 ]
 isort.order-by-type = false
+
+[lint.per-file-ignores]
+"tests/**" = [
+    "S101",  # Allow usage of pytest `assert`
+    "TC003",  # Ignore performance overhead of imports only used for type checking
+]
 
 [format]
 docstring-code-format = true

--- a/exports/ystdlib-py/pyproject.toml
+++ b/exports/ystdlib-py/pyproject.toml
@@ -33,6 +33,7 @@ line-length = 100
 [tool.ruff.lint]
 select = ["ALL"]
 ignore = [
+    "ANN401", # Allow using Any type for function signatures
     "COM812",  # Redundant and conflicts with ruff format
     "D203",  # No blank line before docstrings (D211)
     "D205",  # Breaks if summary is larger than one line due to wrapping or if no summary exists
@@ -45,12 +46,20 @@ ignore = [
     "PERF401",  # Allow for loops when creating lists
     "PERF403",  # Allow for loops when creating dicts
     "S311",  # Allow usage of `random` package
+    "S603", # Automatically trust inputs of subprocess execution
     "SIM102",  # Allow collapsible if statements for readability
+    "SIM300", # Skip Yoda-condition format fixes
     "TD002",  # Author unnecessary for todo statement
     "TD003",  # Issue link unnecessary for todo statement
     "UP015",  # Explicit open modes are helpful
 ]
 isort.order-by-type = false
+
+[tool.ruff.lint.per-file-ignores]
+"tests/**" = [
+    "S101",  # Allow usage of pytest `assert`
+    "TC003",  # Ignore performance overhead of imports only used for type checking
+]
 
 [tool.ruff.format]
 docstring-code-format = true


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As title. Rules specific to `pytest` are enabled only for the `tests` directory. The updated ruff rule exclusion list is in line with what's currently used in CLP [integration-tests](https://github.com/y-scope/clp/blob/16d95b15a54b9a1a6cde5c6114698bca005c16fc/integration-tests/pyproject.toml).

The newly added rules and the reasons why they were added are:
- `ANN401`
  - used for functions that takes in `**kwargs`.
  - used for return signature `subprocess.CompletedProcess[Any]`
- `S603`
  - it is cumbersome to validate all arguments passed into any `subprocess` invocation. For example, it's hard to validate that the log tarball download urls are not malicious.
- `SIM300`
  - YScope guidelines prefer condition checks with literals on the LHS (e.g. `if 0 == len(abc)`). Without this rule exclusion, `ruff` tries to fix these reversed orders

Python tests only:
- `S101`
  - We currently use `pytest` for test infrastructure, so we need to enable the use of `pytest` assert
- `TC003`
  - `pathlib.Path` in [this testing file](https://github.com/y-scope/clp/blob/16d95b15a54b9a1a6cde5c6114698bca005c16fc/integration-tests/tests/utils/config.py) is only used for type checking and not used during execution.
  - Importing python modules incurs overheads, but such small overheads can be overlooked when we are running only tests

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Linting for `ystdlib-py` succeeds.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated Python linting rules to reduce false positives and streamline development.
  - Allowed use of Any in function signatures where appropriate.
  - Relaxed security and style checks for subprocess inputs and Yoda-condition patterns.
  - Added test-specific ignores to permit pytest-style asserts and type-check-only imports.
  - Improved CI reliability and developer experience without changing runtime behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->