### PR TITLE
feat(lint-configs): Add Rustfmt lint config.

### DIFF
--- a/exports/lint-configs/.rustfmt.toml
+++ b/exports/lint-configs/.rustfmt.toml
@@ -1,0 +1,53 @@
+# Stable Options
+# This section only contains overrides to the defaults.
+max_width = 100 # Default value; set explicitly for clarity
+newline_style = "Unix"
+tab_spaces = 4 # Default value; set explicitly for clarity
+use_field_init_shorthand = true
+
+# Unstable Options (nightly only)
+# This section lists all unstable options. Values are set to their defaults unless noted otherwise.
+binop_separator = "Front"
+blank_lines_lower_bound = 0
+blank_lines_upper_bound = 1
+brace_style = "PreferSameLine"
+color = "Auto"
+combine_control_expr = true
+comment_width = 100 # Non-default
+condense_wildcard_suffixes = true # Non-default
+control_brace_style = "AlwaysSameLine"
+empty_item_single_line = true
+enum_discrim_align_threshold = 0
+error_on_line_overflow = true # Non-default
+error_on_unformatted = true # Non-default
+fn_single_line = false
+force_multiline_blocks = false
+format_code_in_doc_comments = false
+format_generated_files = true
+format_macro_matchers = false
+format_macro_bodies = true
+format_strings = true # Non-default
+group_imports = "StdExternalCrate" # Non-default
+hex_literal_case = "Lower" # Non-default
+show_parse_errors = true
+imports_indent = "Block"
+imports_granularity = "Crate" # Non-default
+imports_layout = "HorizontalVertical"
+indent_style = "Block"
+inline_attribute_width = 0
+match_arm_blocks = true
+normalize_comments = true # Non-default
+normalize_doc_attributes = true # Non-default
+overflow_delimited_expr = false
+reorder_impl_items = true # Non-default
+skip_children = false
+space_after_colon = true
+space_before_colon = false
+spaces_around_ranges = false
+struct_field_align_threshold = 0
+trailing_comma = "Vertical"
+trailing_semicolon = true
+type_punctuation_density = "Wide"
+unstable_features = true
+where_single_line = false
+wrap_comments = true # Non-default


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

This PR introduces the lint config for `Rustfmt` for Rust version 1.8.0. The full rule list can be found [here](https://rust-lang.github.io/rustfmt/?version=v1.8.0&search=).

In this config, there are two section:
- The first section contains lint configs for stable features. In this section, only ones different from the defaults are set.
- The second section contains unstable features (which require nightly version Rustfmt). In this section, all options are explicitly set, and non-default values are explicitly documented. This is to prevent future iterations of the rule from changing the default values.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* Tested on my prototype to ensure this config is properly configured: https://github.com/LinZhihao-723/LogIngestorServer/commit/004f6da686dd750d4e7131943ab522db10466e47.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None. No user-facing changes.
- Style
  - Enforced consistent Rust code formatting across the project, covering line width, indentation, import grouping, and comment wrapping.
- Chores
  - Added a project-wide Rust formatter configuration compatible with stable and nightly toolchains to standardize code style in development workflows.
- Bug Fixes
  - None.
- Documentation
  - None.
- Tests
  - None.
- Refactor
  - None.
- Revert
  - None.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->