### PR TITLE
refactor(lint-configs): Extract `symlink_config` from `symlink-cpp-lint-configs.sh` as a helper script.

### DIFF
--- a/exports/lint-configs/symlink-config.sh
+++ b/exports/lint-configs/symlink-config.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Usage: symlink-config.sh <config-file-path>
+# Symlinks the given config file to the repo's root.
+
+# Exit on any error
+set -e
+
+# Error on undefined variable
+set -u
+
+main () {
+    if [ "$#" -ne 1 ]; then
+        echo "Usage: symlink-config.sh <config-file-path>" >&2
+        exit 1
+    fi
+
+    config_file_path="$1"
+    if [ ! -f "$config_file_path" ]; then
+        echo "symlink-config.sh: Config file doesn't exist: '$config_file_path'." >&2
+        exit 1
+    fi
+
+    repo_dir="$(git rev-parse --show-toplevel)"
+    config_file_absolute_path="$(readlink -f "$config_file_path")"
+
+    # Ensure $repo_dir has a single trailing slash
+    repo_dir="${repo_dir%/}/"
+
+    # Get the config file's path relative to the repo root
+    # NOTE: This is a bit fragile since it depends on $repo_dir having a single trailing slash.
+    # Ideally, we would use `realpath --relative-to` instead of variable substitution, but
+    # `--relative-to` isn't available on macOS.
+    repo_relative_config_file_path="${config_file_absolute_path#"${repo_dir}"}"
+
+    src_path="${repo_dir}/${repo_relative_config_file_path}"
+    dst_path="${repo_dir}/$(basename "$config_file_path")"
+
+    # NOTE: `-e` will return false if the file is a broken symlink, so that's why we also check
+    # `-L`.
+    if [ ! -e "$dst_path" ] && [ ! -L "$dst_path" ]; then
+        ln -s "$repo_relative_config_file_path" "$dst_path"
+        echo "Symlinked '${src_path}' to '${dst_path}'."
+    elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
+        echo "Unknown config file exists at '${dst_path}'. Remove it before running this script." \
+            >&2
+        exit 1
+    else
+        echo "Already symlinked '${src_path}' to '${dst_path}'."
+    fi
+}
+
+main "$@"

--- a/exports/lint-configs/symlink-cpp-lint-configs.sh
+++ b/exports/lint-configs/symlink-cpp-lint-configs.sh
@@ -8,59 +8,9 @@ set -u
 
 script_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 
-# Symlinks the given config file to the repo's root.
-#
-# @param $1 Path to the config file in the repo.
-symlink_config () {
-    if [ "$#" -ne 1 ]; then
-        echo "Usage: symlink_config <config-file-path>" >&2
-        return 1
-    fi
-
-    config_file_path="$1"
-    if [ ! -f "$config_file_path" ]; then
-        echo "symlink_config: Config file doesn't exist: '$config_file_path'." >&2
-        return 1
-    fi
-
-    repo_dir="$(git rev-parse --show-toplevel)"
-    config_file_absolute_path="$(readlink -f "$config_file_path")"
-
-    # Ensure $repo_dir has a single trailing slash
-    repo_dir="${repo_dir%/}/"
-
-    # Get the config file's path relative to the repo root
-    # NOTE: This is a bit fragile since it depends on $repo_dir having a single trailing slash.
-    # Ideally, we would use `realpath --relative-to` instead of variable substitution, but
-    # `--relative-to` isn't available on macOS.
-    repo_relative_config_file_path="${config_file_absolute_path#"${repo_dir}"}"
-
-    src_path="${repo_dir}/${repo_relative_config_file_path}"
-    dst_path="${repo_dir}/$(basename "$config_file_path")"
-
-    # NOTE: `-e` will return false if the file is a broken symlink, so that's why we also check
-    # `-L`.
-    if [ ! -e "$dst_path" ] && [ ! -L "$dst_path" ]; then
-        ln -s "$repo_relative_config_file_path" "$dst_path"
-        echo "Symlinked '${src_path}' to '${dst_path}'."
-    elif [ "$(readlink -f "$src_path")" != "$(readlink -f "$dst_path")" ]; then
-        echo "Unknown config file exists at '${dst_path}'. Remove it before running this script." \
-            >&2
-        return 1
-    else
-        echo "Already symlinked '${src_path}' to '${dst_path}'."
-    fi
-
-    return 0
-}
-
 main () {
-    if ! symlink_config "${script_dir}/.clang-format"; then
-        exit 1
-    fi
-    if ! symlink_config "${script_dir}/.clang-tidy"; then
-        exit 1
-    fi
+    "${script_dir}/symlink-config.sh" "${script_dir}/.clang-format"
+    "${script_dir}/symlink-config.sh" "${script_dir}/.clang-tidy"
 }
 
 main "$@"


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

As we will introduce linting configs for Rust, `symlink_config` will be reused in another script called `symlink-rust-lint-configs.sh`. This PR extracts the helper into a single helper shell script for code sharing.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

Did the following tests:

```shell
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  ./exports/lint-configs/symlink-cpp-lint-configs.sh
Symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-format' to '/home/lzh/yscope-dev-utils//.clang-format'.
Symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-tidy' to '/home/lzh/yscope-dev-utils//.clang-tidy'.
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  echo $?
0
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  rm -rf .clang-*
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  cat README.md > .clang-tidy
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  ./exports/lint-configs/symlink-cpp-lint-configs.sh
Symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-format' to '/home/lzh/yscope-dev-utils//.clang-format'.
Unknown config file exists at '/home/lzh/yscope-dev-utils//.clang-tidy'. Remove it before running this script.
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  echo $?
1
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  rm -rf .clang-*
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  ./exports/lint-configs/symlink-cpp-lint-configs.sh
Symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-format' to '/home/lzh/yscope-dev-utils//.clang-format'.
Symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-tidy' to '/home/lzh/yscope-dev-utils//.clang-tidy'.
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  ./exports/lint-configs/symlink-cpp-lint-configs.sh
Already symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-format' to '/home/lzh/yscope-dev-utils//.clang-format'.
Already symlinked '/home/lzh/yscope-dev-utils//exports/lint-configs/.clang-tidy' to '/home/lzh/yscope-dev-utils//.clang-tidy'.
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  echo $?
0
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  ./exports/lint-configs/symlink-config.sh hi.txt
symlink-config.sh: Config file doesn't exist: 'hi.txt'.
☁  yscope-dev-utils [symlink-rust-lint-configs] ⚡  echo $?
1
```

- Creating symlinks for C++ lint-configs will succeed.
- If a file with the linking name already exists, it will fail by returning 1.
- If running the script twice, it won't fail and will properly notify that the symlink has been created.
- If the config to link doesn't exist, it will fail by returning 1.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a CLI utility to create relative symlinks for linter/formatter configs at the repository root, with validation, conflict checks, idempotent behaviour, and clear messages.
* Refactor
  * Updated existing tooling to delegate symlink creation to the new utility, reducing duplication and centralising logic.
* Chores
  * Improved robustness with strict error handling and path normalisation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->