### PR TITLE
chore(taskfiles): Ensure parent directory exists before writing checksum file in `compute:checksum`.

### DIFF
--- a/exports/taskfiles/utils/checksum.yaml
+++ b/exports/taskfiles/utils/checksum.yaml
@@ -16,6 +16,7 @@ tasks:
     requires:
       vars: ["CHECKSUM_FILE", "INCLUDE_PATTERNS"]
     cmds:
+      - "mkdir -p '{{ dir .CHECKSUM_FILE }}'"
       # We explicitly set `--no-anchored` and `--wildcards` to make the inclusion behaviour match
       # the default exclusion behaviour.
       #


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

For `checksum:compute`, automatically create the parent directory for the checksum file before writing the MD5 checksum output so users don’t need to manually create it.

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [X] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [X] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [X] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->

* [X] Syntax is correct.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by ensuring required directories are properly initialized before file operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->