### PR TITLE
fix(lint-configs): Add `/**/` to `ruff.lint.per-file-ignores` pattern to allow it to be extended (fixes #97); Consolidate ruff configuration by extending the shared config.

### DIFF
--- a/exports/lint-configs/python/README.md
+++ b/exports/lint-configs/python/README.md
@@ -3,7 +3,20 @@
 This directory contains standalone, working Python linter configuration files that serve as
 reference settings for integrating these linters into your project.
 
-For a project with its own `pyproject.toml` file, at the time of writing, there is no clean, general
-solution for including the standalone configuration files for different linters. In this scenario,
-the settings inside the configuration files should be copied into your `pyproject.toml` file, as
-seen in [ystdlib-py/pyproject.toml](../../ystdlib-py/pyproject.toml).
+## Integration Methods
+
+### Ruff
+
+Ruff supports the `extend` directive. Add this to your `pyproject.toml`:
+
+```toml
+[tool.ruff]
+extend = "path/to/yscope-dev-utils/exports/lint-configs/python/ruff.toml"
+```
+
+See [ystdlib-py/pyproject.toml](../../ystdlib-py/pyproject.toml) for an example.
+
+### Mypy
+
+Mypy does not support extending external configuration files. Copy the settings from `mypy.ini`
+into your `pyproject.toml` under `[tool.mypy]`.

--- a/exports/lint-configs/python/ruff.toml
+++ b/exports/lint-configs/python/ruff.toml
@@ -26,7 +26,7 @@ ignore = [
 isort.order-by-type = false
 
 [lint.per-file-ignores]
-"tests/**" = [
+"/**/tests/**" = [
     "S101",  # Allow usage of pytest `assert`
     "TC003",  # Ignore performance overhead of imports only used for type checking
 ]

--- a/exports/ystdlib-py/pyproject.toml
+++ b/exports/ystdlib-py/pyproject.toml
@@ -28,39 +28,4 @@ show_error_context = true
 show_error_end = true
 
 [tool.ruff]
-line-length = 100
-
-[tool.ruff.lint]
-select = ["ALL"]
-ignore = [
-    "ANN401", # Allow using Any type for function signatures
-    "COM812",  # Redundant and conflicts with ruff format
-    "D203",  # No blank line before docstrings (D211)
-    "D205",  # Breaks if summary is larger than one line due to wrapping or if no summary exists
-    "D212",  # Enforce docstring summary line on the next line after quotes (D213)
-    "D400",  # First line of docstrings may not end in period
-    "D401",  # Docstrings should be written in present tense (not imperative)
-    "D415",  # First line of docstrings may not end in a period, question mark, or exclamation point
-    "FBT",  # Allow bool positional parameters since other value positions are allowed
-    "FIX002",  # Allow todo statements
-    "PERF401",  # Allow for loops when creating lists
-    "PERF403",  # Allow for loops when creating dicts
-    "S311",  # Allow usage of `random` package
-    "S603", # Automatically trust inputs of subprocess execution
-    "SIM102",  # Allow collapsible if statements for readability
-    "SIM300", # Skip Yoda-condition format fixes
-    "TD002",  # Author unnecessary for todo statement
-    "TD003",  # Issue link unnecessary for todo statement
-    "UP015",  # Explicit open modes are helpful
-]
-isort.order-by-type = false
-
-[tool.ruff.lint.per-file-ignores]
-"tests/**" = [
-    "S101",  # Allow usage of pytest `assert`
-    "TC003",  # Ignore performance overhead of imports only used for type checking
-]
-
-[tool.ruff.format]
-docstring-code-format = true
-docstring-code-line-length = 100
+extend = "../lint-configs/python/ruff.toml"


### PR DESCRIPTION
# Description

This PR fixes #97 by updating the ruff per-file-ignores pattern to support extending the shared configuration across projects.

## Changes

1. **Updated `ruff.toml` pattern**: Changed `"tests/**"` to `"/**/tests/**"` to match test directories at any level when extended
2. **Added extend documentation**: Updated README with instructions on using the `extend` directive for ruff
3. **Refactored `ystdlib-py`**: Consolidated configuration by extending the shared ruff config instead of duplicating 36 lines

## Context

When projects extend the ruff config using `extend = "path/to/ruff.toml"`, the old pattern `"tests/**"` was resolved relative to the config file location, not the extending project's root. This prevented the per-file-ignores from working correctly in extending projects.

The new pattern `"/**/tests/**"` matches test directories anywhere in the project hierarchy, making it work correctly for both standalone use and when extended by other projects.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

- In `clp`'s `integration-tests`, verified the new pattern correctly ignores S101 and TC003 rules in test directories at any level
- Tested with `extend` directive to confirm it works in extending projects  
- Confirmed all lint checks pass with the new configuration
- Validated ystdlib-py successfully uses the extended config

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated Python linting integration guidance with Ruff setup instructions.

* **Chores**
  * Expanded test directory ignore pattern for Python linting across all project depths.
  * Consolidated Python linting configuration through external configuration reference, reducing duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->