### PR TITLE
fix(lint-configs): Suppress clang-tidy unnecessary-copy warnings for `std::shared_ptr` as the copy is necessary for reference counting.

### DIFF
--- a/exports/lint-configs/.clang-tidy
+++ b/exports/lint-configs/.clang-tidy
@@ -51,8 +51,13 @@ CheckOptions:
   cert-str34-c.CharTypdefsToIgnore: "int8_t"
 
   # This is necessary to allow simple classes (with all members being public) that have a
-  # constructor
+  # constructor.
   misc-non-private-member-variables-in-classes.IgnoreClassesWithAllMemberVariablesBeingPublic: true
+
+  # Passing a reference counted type by reference will skip the usage of the reference count, which
+  # risks lifetime related bugs.
+  performance-unnecessary-copy-initialization.AllowedTypes: "std::shared_ptr"
+  performance-unnecessary-value-param.AllowedTypes: "std::shared_ptr"
 
   # NOTE: In the naming rules below, a rule may imply another (e.g., `ClassCase` seems to imply
   # `AbstractClassCase`), so ideally we'd only specify the parent rule if we didn't need to


### PR DESCRIPTION
<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->

The clang-tidy checks `unnecessary-copy-initialization` and `unnecessary-value-param` help devs to avoid unnecessary copies by pointing out when it is possible to use `const&`. This is great most of the time, but these checks will also flag reference counting types.

In our code this issue manifests primarily with `std::shared_ptr` function parameters. When the shared pointer would be copy constructed the reference count would be increased, however if the dev switches to `std::shared_ptr const&` there will be no reference counting as there is no construction. It is technically safe to do this as long as the object being referenced is guaranteed to not fall out of scope while the reference is held, but it is much easier to reason about reference counted types when they always perform the counting.
If performing these copies is ever a serious performance concern we should probably be investigating how to not use shared_ptrs entirely than skipping the copy.

There are other referencing counting stdlib types that this applies to, but I think we can add them on a case-by-case basis.


https://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-copy-initialization.html
https://clang.llvm.org/extra/clang-tidy/checks/performance/unnecessary-value-param.html
https://github.com/llvm/llvm-project/issues/153247

# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

I've been building y-scope/clp/main and davidlion/clp/clpp with these changes.



[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to better handle reference-counted types in performance checks.
  * Allowed shared pointers in additional performance-related checks, with clearer guidance in the configuration comments.
  * Improved nearby comment punctuation for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->