### PR TITLE
fix(cmake): Explicitly use the logical CPU count when `JOBS` is unset.

### DIFF
--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -15,7 +15,8 @@ tasks:
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, defaults to the number of logical CPUs (via `nproc`/`sysctl`).
+  # omitted, defaults to the number of logical CPUs reported by the system. Falls back to 1 for a
+  # serial build if the CPU count cannot be determined.
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -27,7 +27,10 @@ tasks:
       # Portable across Linux (`nproc`) and macOS (`sysctl`).
       _CPU_COUNT:
         sh: |-
-          nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 1
+          nproc 2>/dev/null \
+            || getconf _NPROCESSORS_ONLN 2>/dev/null \
+            || sysctl -n hw.logicalcpu 2>/dev/null \
+            || echo 1
       JOBS: >-
         {{default ._CPU_COUNT .JOBS}}
       TARGETS:

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -25,7 +25,7 @@ tasks:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
       # Number of logical CPUs, used as the default for `JOBS` when the caller doesn't set it.
-      # Portable across Linux (`nproc`) and macOS (`sysctl`).
+      # Portable across Linux (`nproc`), POSIX (`getconf`), and macOS (`sysctl`).
       _CPU_COUNT:
         sh: |-
           nproc 2>/dev/null \

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -15,8 +15,7 @@ tasks:
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, defaults to the number of logical CPUs (via `nproc`/`sysctl`), matching the
-  # `boost:build-and-install` default.
+  # omitted, defaults to the number of logical CPUs (via `nproc`/`sysctl`).
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -15,7 +15,8 @@ tasks:
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
   # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the native build tool's default number is used. See `man cmake`.
+  # omitted, defaults to the number of logical CPUs (via `nproc`/`sysctl`), matching the
+  # `boost:build-and-install` default.
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true
@@ -23,8 +24,13 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
+      # Number of logical CPUs, used as the default for `JOBS` when the caller doesn't set it.
+      # Portable across Linux (`nproc`) and macOS (`sysctl`).
+      _CPU_COUNT:
+        sh: |-
+          nproc 2>/dev/null || sysctl -n hw.logicalcpu 2>/dev/null || echo 1
       JOBS: >-
-        {{default "" .JOBS}}
+        {{default ._CPU_COUNT .JOBS}}
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:
@@ -33,9 +39,7 @@ tasks:
       - >-
         cmake
         --build "{{.BUILD_DIR}}"
-        {{- if .JOBS}}
         --parallel "{{.JOBS}}"
-        {{- end}}
         {{- range .TARGETS}}
         --target="{{.}}"
         {{- end}}
@@ -156,7 +160,7 @@ tasks:
   # @param {string[]} [CMAKE_INSTALL_ARGS] Any additional arguments to pass to the CMake install
   # command.
   # @param {int} [CMAKE_JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the native build tool's default number is used. See `man cmake`.
+  # omitted, defaults to the number of logical CPUs (see `build`'s `JOBS`).
   # @param {string} [CMAKE_SETTINGS_DIR] The directory where the project's CMake settings file
   # should be stored.
   # @param {string} [CMAKE_SOURCE_DIR=.] The path, within the extraction directory, containing the

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -33,7 +33,9 @@ tasks:
       - >-
         cmake
         --build "{{.BUILD_DIR}}"
+        {{- if .JOBS}}
         --parallel "{{.JOBS}}"
+        {{- end}}
         {{- range .TARGETS}}
         --target="{{.}}"
         {{- end}}

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -159,7 +159,8 @@ tasks:
   # @param {string[]} [CMAKE_INSTALL_ARGS] Any additional arguments to pass to the CMake install
   # command.
   # @param {int} [CMAKE_JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, defaults to the number of logical CPUs (see `build`'s `JOBS`).
+  # omitted, defaults to the number of logical CPUs reported by the system. Falls back to 1 for a
+  # serial build if the CPU count cannot be determined.
   # @param {string} [CMAKE_SETTINGS_DIR] The directory where the project's CMake settings file
   # should be stored.
   # @param {string} [CMAKE_SOURCE_DIR=.] The path, within the extraction directory, containing the


### PR DESCRIPTION
## Description

`cmake:build` always emitted `--parallel "{{.JOBS}}"` with `JOBS` defaulting to the empty string, so an unset `JOBS` rendered `cmake --build <dir> --parallel ""`. cmake turns that into bare `gmake -f Makefile -j`, i.e. **unbounded parallelism** — a single build could spawn far more compiler processes than there are cores, oversubscribing the machine and risking OOM on large dependencies like folly.

Bound the default to the number of logical CPUs (`nproc`/`sysctl`, falling back to `1`), so `--parallel` always receives a finite, right-sized value and a single build no longer oversubscribes. Callers can still override via `JOBS` (or `CMAKE_JOBS`, which flows through `install-remote-tar` -> `build`).

This matches `boost:build-and-install` (b2 defaults to the core count for boost >= 1.76.0). Cross-build scheduling — running several `cmake:build` invocations concurrently — remains the caller's responsibility; set `JOBS` lower to avoid oversubscribing across builds.

Cross-platform: `nproc` (Linux) -> `sysctl -n hw.logicalcpu` (macOS) -> `echo 1`.

## Validation performed

`task lint:check` and `task test` pass.

Scratch `Taskfile.yml` including `utils/utils.yaml`, wrapping `utils:cmake:build` (host has 12 logical CPUs):

| Input | Rendered command |
|---|---|
| no `JOBS` | `cmake --build "build" --parallel "12"` |
| `JOBS=` (explicit empty) | `cmake --build "build" --parallel "12"` |
| `JOBS=5` | `cmake --build "build" --parallel "5"` (override respected) |

For reference, the pre-fix empty case rendered `--parallel ""` -> bare `gmake -f Makefile -j` (unlimited).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Build tasks now default to a sensible CPU-count-based parallel job value when no job count is provided, improving performance out of the box.
  * Updated installation task documentation so its job-setting guidance matches the build task’s CPU-count default behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->