### PR TITLE
fix(taskfiles): Improve concurrency control for external tools:

### DIFF
--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -62,8 +62,8 @@ tasks:
   # @param {string} BUILD_DIR Directory in which to build boost.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_JOBS")}}] The maximum number of concurrent
-  # processes to use when building.
+  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")}}] The maximum
+  # number of concurrent processes to use when building.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   build-and-install:
@@ -71,7 +71,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: '{{default (default .G_NPROCS (env "TASK_JOBS")) .JOBS}}'
+      JOBS: '{{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}'
     requires:
       vars: ["GENERATE_DIR", "BUILD_DIR", "INSTALL_PREFIX"]
     cmds:

--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -71,7 +71,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: '{{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}'
+      JOBS: "{{default (default .G_NPROCS (env 'TASK_EXTERNAL_TOOL_CONCURRENCY')) .JOBS}}"
     requires:
       vars: ["GENERATE_DIR", "BUILD_DIR", "INSTALL_PREFIX"]
     cmds:

--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -8,10 +8,6 @@ includes:
 set: ["u", "pipefail"]
 shopt: ["globstar"]
 
-# `JOBS` is a special variable name and is used for concurrency related variables to allow users to
-# override all concurrency when invoking task. Callers using these tasks should default to `JOBS` to
-# propagate any user set value.
-
 tasks:
   # Generates `GENERATE_DIR` by copying `SOURCE_DIR` and then running boost's bootstrap step.
   #
@@ -66,8 +62,8 @@ tasks:
   # @param {string} BUILD_DIR Directory in which to build boost.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS=G_NPROCS] The maximum number of concurrent processes to use when building. If
-  # omitted, the number of cores is used.
+  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_JOBS")}}] The maximum number of concurrent
+  # processes to use when building.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   build-and-install:
@@ -75,7 +71,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: "{{default .G_NPROCS .JOBS}}"
+      JOBS: '{{default (default .G_NPROCS (env "TASK_JOBS")) .JOBS}}'
     requires:
       vars: ["GENERATE_DIR", "BUILD_DIR", "INSTALL_PREFIX"]
     cmds:

--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -71,7 +71,8 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: "{{default (default .G_NPROCS (env 'TASK_EXTERNAL_TOOL_CONCURRENCY')) .JOBS}}"
+      JOBS: >-
+        {{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}
     requires:
       vars: ["GENERATE_DIR", "BUILD_DIR", "INSTALL_PREFIX"]
     cmds:

--- a/exports/taskfiles/utils/boost.yaml
+++ b/exports/taskfiles/utils/boost.yaml
@@ -2,10 +2,15 @@ version: "3"
 
 includes:
   checksum: "checksum.yaml"
+  misc: "misc.yaml"
   remote: "remote.yaml"
 
 set: ["u", "pipefail"]
 shopt: ["globstar"]
+
+# `JOBS` is a special variable name and is used for concurrency related variables to allow users to
+# override all concurrency when invoking task. Callers using these tasks should default to `JOBS` to
+# propagate any user set value.
 
 tasks:
   # Generates `GENERATE_DIR` by copying `SOURCE_DIR` and then running boost's bootstrap step.
@@ -61,9 +66,8 @@ tasks:
   # @param {string} BUILD_DIR Directory in which to build boost.
   # @param {string} INSTALL_PREFIX Path prefix of where the project should be installed.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the b2 default number is used. Before 1.76.0, the number was 1. Since 1.76.0, the
-  # default is the number of cores.
+  # @param {int} [JOBS=G_NPROCS] The maximum number of concurrent processes to use when building. If
+  # omitted, the number of cores is used.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
   # file should be stored.
   build-and-install:
@@ -71,8 +75,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: >-
-        {{default "" .JOBS}}
+      JOBS: "{{default .G_NPROCS .JOBS}}"
     requires:
       vars: ["GENERATE_DIR", "BUILD_DIR", "INSTALL_PREFIX"]
     cmds:
@@ -121,9 +124,7 @@ tasks:
   #
   # Boost build-and-install parameters
   # @param {string} [BUILD_DIR={{.WORK_DIR}}/boost-build] Directory in which to build the project.
-  # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the b2 default number is used. Before 1.76.0, the number was 1. Since 1.76.0, the
-  # default is the number of cores.
+  # @param {int} [JOBS] The maximum number of concurrent processes to use when building.
   # @param {string[]} [BUILD_AND_INSTALL_ARGS] Any additional arguments to pass to boost's build
   # and install command.
   # @param {string} [CMAKE_SETTINGS_DIR] If set, the directory where the project's CMake settings
@@ -155,8 +156,6 @@ tasks:
         {{default (printf "%s/boost-build" .WORK_DIR) .BUILD_DIR}}
       BUILD_AND_INSTALL_ARGS:
         ref: "default (list) .BUILD_AND_INSTALL_ARGS"
-      JOBS: >-
-        {{default "" .JOBS}}
       CMAKE_SETTINGS_DIR: >-
         {{default "" .CMAKE_SETTINGS_DIR}}
     requires:

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -23,7 +23,8 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: "{{default (default .G_NPROCS (env 'TASK_EXTERNAL_TOOL_CONCURRENCY')) .JOBS}}"
+      JOBS: >-
+        {{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -23,7 +23,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: '{{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}'
+      JOBS: "{{default (default .G_NPROCS (env 'TASK_EXTERNAL_TOOL_CONCURRENCY')) .JOBS}}"
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -7,10 +7,6 @@ includes:
 set: ["u", "pipefail"]
 shopt: ["globstar"]
 
-# `JOBS` is a special variable name and is used for concurrency related variables to allow users to
-# override all concurrency when invoking task. Callers using these tasks should default to `JOBS` to
-# propagate any user set value.
-
 tasks:
   # Runs the CMake build step for the given build directory. The caller must have previously called
   # `generate` on `BUILD_DIR` for this task to succeed. We purposely omit `sources` and `generates`
@@ -18,8 +14,8 @@ tasks:
   #
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS=G_NPROCS] The maximum number of concurrent processes to use when building. If
-  # omitted, the number of cores is used.
+  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_JOBS")}}] The maximum number of concurrent
+  # processes to use when building.
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true
@@ -27,7 +23,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: "{{default .G_NPROCS .JOBS}}"
+      JOBS: '{{default (default .G_NPROCS (env "TASK_JOBS")) .JOBS}}'
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:
@@ -174,7 +170,6 @@ tasks:
         ref: "default (list) .CMAKE_GEN_ARGS"
       CMAKE_INSTALL_ARGS:
         ref: "default (list) .CMAKE_INSTALL_ARGS"
-      CMAKE_JOBS: "{{default .JOBS .CMAKE_JOBS}}"
       CMAKE_SETTINGS_DIR: >-
         {{default "" .CMAKE_SETTINGS_DIR}}
       CMAKE_SOURCE_DIR: >-

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -7,6 +7,10 @@ includes:
 set: ["u", "pipefail"]
 shopt: ["globstar"]
 
+# `JOBS` is a special variable name and is used for concurrency related variables to allow users to
+# override all concurrency when invoking task. Callers using these tasks should default to `JOBS` to
+# propagate any user set value.
+
 tasks:
   # Runs the CMake build step for the given build directory. The caller must have previously called
   # `generate` on `BUILD_DIR` for this task to succeed. We purposely omit `sources` and `generates`
@@ -14,8 +18,8 @@ tasks:
   #
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the native build tool's default number is used. See `man cmake`.
+  # @param {int} [JOBS=G_NPROCS] The maximum number of concurrent processes to use when building. If
+  # omitted, the number of cores is used.
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true
@@ -23,8 +27,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: >-
-        {{default "" .JOBS}}
+      JOBS: "{{default .G_NPROCS .JOBS}}"
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:
@@ -153,8 +156,7 @@ tasks:
   # command.
   # @param {string[]} [CMAKE_INSTALL_ARGS] Any additional arguments to pass to the CMake install
   # command.
-  # @param {int} [CMAKE_JOBS] The maximum number of concurrent processes to use when building. If
-  # omitted, the native build tool's default number is used. See `man cmake`.
+  # @param {int} [CMAKE_JOBS] The maximum number of concurrent processes to use when building.
   # @param {string} [CMAKE_SETTINGS_DIR] The directory where the project's CMake settings file
   # should be stored.
   # @param {string} [CMAKE_SOURCE_DIR=.] The path, within the extraction directory, containing the
@@ -172,8 +174,7 @@ tasks:
         ref: "default (list) .CMAKE_GEN_ARGS"
       CMAKE_INSTALL_ARGS:
         ref: "default (list) .CMAKE_INSTALL_ARGS"
-      CMAKE_JOBS: >-
-        {{default "" .CMAKE_JOBS}}
+      CMAKE_JOBS: "{{default .JOBS .CMAKE_JOBS}}"
       CMAKE_SETTINGS_DIR: >-
         {{default "" .CMAKE_SETTINGS_DIR}}
       CMAKE_SOURCE_DIR: >-

--- a/exports/taskfiles/utils/cmake.yaml
+++ b/exports/taskfiles/utils/cmake.yaml
@@ -14,8 +14,8 @@ tasks:
   #
   # @param {string} BUILD_DIR Directory containing the generated build system to use.
   # @param {string[]} [EXTRA_ARGS] Any additional arguments to pass to the build command.
-  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_JOBS")}}] The maximum number of concurrent
-  # processes to use when building.
+  # @param {int} [JOBS={{default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")}}] The maximum
+  # number of concurrent processes to use when building.
   # @param {string[]} [TARGETS] A list of specific targets to build instead of the default target.
   build:
     internal: true
@@ -23,7 +23,7 @@ tasks:
     vars:
       EXTRA_ARGS:
         ref: "default (list) .EXTRA_ARGS"
-      JOBS: '{{default (default .G_NPROCS (env "TASK_JOBS")) .JOBS}}'
+      JOBS: '{{default (default .G_NPROCS (env "TASK_EXTERNAL_TOOL_CONCURRENCY")) .JOBS}}'
       TARGETS:
         ref: "default (list) .TARGETS"
     requires:

--- a/exports/taskfiles/utils/misc.yaml
+++ b/exports/taskfiles/utils/misc.yaml
@@ -3,6 +3,10 @@ version: "3"
 set: ["u", "pipefail"]
 shopt: ["globstar"]
 
+vars:
+  G_NPROCS:
+    sh: "getconf _NPROCESSORS_ONLN"
+
 tasks:
   replace-text:
     desc: "Replaces some text in a file using sed."


### PR DESCRIPTION
- Default to the number of logical processors.
- Allow users to control the default through the env var `TASK_EXTERNAL_TOOL_CONCURRENCY`.

<!-- markdownlint-disable MD012 -->

<!--
Set the PR title to a meaningful commit message that:

* is in imperative form.
* follows the Conventional Commits specification (https://www.conventionalcommits.org).
  * See https://github.com/commitizen/conventional-commit-types/blob/master/index.json for possible
    types.

Example:

fix: Don't add implicit wildcards ('*') at the beginning and the end of a query (fixes #390).
-->

# Description

<!-- Describe what this request will change/fix and provide any details necessary for reviewers. -->
Currently, concurrency variables are not handled consistently so a user cannot easily control the concurrency from the command line. The goal of this PR is to create a consistent flow for users to easily control concurrency in resource limited scenarios.

For example, most tasks use the variable `JOBS`, but cmake also has a task that uses `CMAKE_JOBS` and passes that value as a `JOBS` argument. If the user sets `JOBS` it will not be respected by the task using `CMAKE_JOBS`. This is further complicated as top-level projects (e.g. CLP) end up using their own ad-hoc variables to control concurrency.

Tasks that set a concurrency related parameter for a tool should (see PR code for example):
1. Use the argument provided by the caller (if non-empty).
2. Use the environment variable `TASK_EXTERNAL_TOOL_CONCURRENCY` (if non-empty).
3. Fallback to the number of logical cores provided by `G_NPROCS` in misc.yaml.

Tasks that propagate a concurrency related parameter should:
1. Propagate it without explicitly setting the value unless they need to always override the user.
   * e.g. if the task `FOO` takes a parameter `JOBS_FOO` and calls `BAR` which takes `JOBS_BAR` it should just directly pass the arg `JOBS_BAR: {{.JOBS_FOO}}`.

A user wishing to set the default concurrency value can either set `TASK_EXTERNAL_TOOL_CONCURRENCY` in their environment, or at the commandline: `TASK_EXTERNAL_TOOL_CONCURRENCY=16 task ...`



# Checklist

<!-- Ensure each item below is satisfied and indicate so by inserting an `x` within each `[ ]`. -->

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a
  breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

<!-- Describe what tests and validation you performed on the change. -->
Manually tested with the boost test and prints.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Build tasks now automatically use all available CPU cores by default when no parallelism value is provided.
  * Parallel build settings can now inherit from a shared default across related workflows.

* **Bug Fixes**
  * Improved consistency in how build concurrency is handled, reducing cases where builds fell back to tool-specific defaults.
  * Updated related task defaults so build and install steps behave more predictably together.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->