### PR TITLE
feat(docker): Support CA certificates during image builds, and add docker build helpers.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -19,4 +19,5 @@ To use the repo's artifacts in your project:
 For language/tool-specific guides, see:
 
 * [CA trust for containerized builds](../exports/docker/ca-trust/README.md)
+* [Docker build helpers](../exports/docker/build/README.md)
 * [Linting for C++ projects](lint-tools-cpp.md)

--- a/exports/docker/build/README.md
+++ b/exports/docker/build/README.md
@@ -1,0 +1,45 @@
+# Docker build
+
+Small helpers for assembling a `docker build` command line.
+
+Building an image from inside a company network usually means repeating the same handful of options every time: send your proxy settings into the build, point the package manager at an internal mirror, refresh the base image, and record which commit the image came from. Every project ends up writing that slightly differently. These functions write it once.
+
+They have nothing to do with certificates — for that, see [ca-trust](../ca-trust/README.md).
+
+## Requirements
+
+* `bash` 3.2 or newer (macOS's `/bin/bash` qualifies).
+* `docker` with `buildx` (Docker 23 or newer). `docker_build_run` checks for it and fails with a clear message if it's missing.
+
+## Usage
+
+```bash
+source tools/yscope-dev-utils/exports/docker/build/host.sh
+
+build_cmd=(docker buildx build --tag <tag> --file <dockerfile> <context>)
+docker_build_finalize build_cmd "${repo_root}" APT_MIRROR_URL
+```
+
+`docker_build_finalize` runs everything below in order. Call the individual functions instead if you need to leave one out.
+
+## What each function does
+
+`docker_build_add_proxy_args <cmd-array-name>` copies your proxy settings into the build, so downloads that happen while the image is being built go through the same proxy your shell uses. It reads `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and `NO_PROXY`, in either upper or lower case.
+
+It also handles a trap that's easy to hit: if your proxy runs on your own machine, the build can't reach it by default, because Docker gives the build its own private network where "this machine" means something else. When an address like `localhost`, `127.0.0.1`, or `[::1]` is detected — including when it's written as `http://user:pass@127.0.0.1:8080` — the build is switched to your machine's network so the proxy is reachable. Set `DOCKER_NETWORK` to choose the network yourself.
+
+`docker_build_add_env_build_args <cmd-array-name> [var-name...]` passes named environment variables into the build, skipping any that aren't set. Use it for your own settings — an internal package mirror, say — without this library needing to know what they're called.
+
+`docker_build_add_pull_arg <cmd-array-name>` re-downloads the base image before building, so you don't silently build on a stale local copy. Set `DOCKER_PULL=false` to skip it, e.g. when building offline.
+
+`docker_build_add_oci_labels <cmd-array-name> <repo-dir>` stamps the image with the commit and repository URL it was built from, so a built image can be traced back to its source. Does nothing if `<repo-dir>` isn't a git checkout.
+
+`docker_build_run <cmd-array-name>` checks that `buildx` is available, prints the assembled command, and runs it.
+
+Both drop credentials from URLs first: a remote like `https://user:token@github.com/org/repo` would otherwise be written into an image label that follows the image to every registry, and a proxy password would end up in the build log. The command itself still runs with the real values.
+
+## Why the functions take an array's *name*
+
+Each function is given the name of a bash array — `build_cmd`, not `"${build_cmd[@]}"` — and appends to it in place, so the command stays a list of separate words. Building it as one long string instead would mean the shell re-splitting that text later, and a proxy or mirror URL containing a space, a quote, or a `$` — common in real ones — would come apart.
+
+Appending by name normally calls for a bash "name reference", but those need bash 4.3 and macOS ships 3.2, so `utils.sh` does it with `printf %q` instead: each value is written in a form the shell reads back as exactly the original bytes.

--- a/exports/docker/build/host.sh
+++ b/exports/docker/build/host.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+
+# Host-side helpers for assembling a `docker build` command.
+#
+# Each function appends flags to a caller-owned bash array, passed by name.
+# docker_utils_append_args does the appending; see utils.sh for why it's written
+# the way it is.
+
+if [[ "${_DOCKER_BUILD_HOST_SH_LOADED:-}" == "1" ]]; then
+    return 0
+fi
+readonly _DOCKER_BUILD_HOST_SH_LOADED=1
+
+# shellcheck source=exports/docker/utils.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)/utils.sh"
+
+# Proxy variables forwarded into the build, in both spellings because tools
+# disagree about which they read.
+readonly _DOCKER_BUILD_PROXY_VARS=(
+    HTTP_PROXY http_proxy
+    HTTPS_PROXY https_proxy
+    ALL_PROXY all_proxy
+    NO_PROXY no_proxy
+)
+
+# Echoes <value> with any URL credentials replaced by <replacement> (removed when
+# that is omitted).
+#
+# Proxy URLs and git remotes both carry credentials in practice --
+# `http://user:token@proxy.corp:8080`, `https://user:token@github.com/org/repo` --
+# and this library would otherwise copy them into an image label or a build log,
+# where they outlive the build.
+#
+# Args: <value> [replacement]
+_docker_build_replace_userinfo() {
+    local value="$1" replacement="${2:-}"
+    # Greedy `.*://` so the last scheme wins, and `[^/@]*` keeps the match inside
+    # the authority: an `@` later in a path is not credentials.
+    if [[ "${value}" =~ ^(.*://)[^/@]*@(.*)$ ]]; then
+        printf '%s%s%s' "${BASH_REMATCH[1]}" "${replacement}" "${BASH_REMATCH[2]}"
+        return 0
+    fi
+    printf '%s' "${value}"
+}
+
+# Appends `--build-arg` flags for any set proxy variables, and picks a network
+# mode.
+#
+# A proxy on the host's loopback address is unreachable from the build
+# container's default bridge network, so `--network host` is selected
+# automatically in that case. DOCKER_NETWORK overrides the choice entirely.
+#
+# Args: <cmd-array-name>
+docker_build_add_proxy_args() {
+    if (( $# != 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: docker_build_add_proxy_args requires a command array"
+        return 2
+    fi
+    local cmd_name="$1"
+
+    local has_loopback_proxy=false
+    local var value
+    for var in "${_DOCKER_BUILD_PROXY_VARS[@]}"; do
+        value="${!var:-}"
+        [[ -z "${value}" ]] && continue
+        docker_utils_append_args "${cmd_name}" "--build-arg" "${var}=${value}"
+        # Match the host after either the scheme or userinfo credentials, so
+        # http://user:pass@127.0.0.1:8080 is recognized too. Also accept a bare
+        # trailing host with no port or path.
+        if [[ "${var}" != *NO_PROXY* && "${var}" != *no_proxy* ]] \
+                && [[ "${value}" =~ (://|@)(localhost|127\.0\.0\.1|\[::1\])([:/]|$) ]]; then
+            has_loopback_proxy=true
+        fi
+    done
+
+    if [[ -n "${DOCKER_NETWORK:-}" ]]; then
+        docker_utils_append_args "${cmd_name}" "--network" "${DOCKER_NETWORK}"
+    elif [[ "${has_loopback_proxy}" == "true" ]]; then
+        docker_utils_append_args "${cmd_name}" "--network" "host"
+    fi
+}
+
+# Appends a `--build-arg` for each named environment variable that is set and
+# non-empty. Lets consumers forward their own build knobs (package mirrors, for
+# instance) without this library knowing their names.
+#
+# Args: <cmd-array-name> [var-name...]
+docker_build_add_env_build_args() {
+    if (( $# < 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: docker_build_add_env_build_args requires a command array"
+        return 2
+    fi
+    local cmd_name="$1"
+    shift
+
+    local var value
+    for var in "$@"; do
+        value="${!var:-}"
+        [[ -n "${value}" ]] && docker_utils_append_args "${cmd_name}" \
+            "--build-arg" "${var}=${value}"
+    done
+    # Explicit: the `&&` above leaves a nonzero status when the last variable is
+    # unset, which would abort callers running under `errexit`.
+    return 0
+}
+
+# Appends `--pull` unless DOCKER_PULL is "false", so builds refresh their base
+# image by default.
+#
+# Args: <cmd-array-name>
+docker_build_add_pull_arg() {
+    if (( $# != 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: docker_build_add_pull_arg requires a command array"
+        return 2
+    fi
+    [[ "${DOCKER_PULL:-true}" != "false" ]] && docker_utils_append_args "$1" "--pull"
+    return 0
+}
+
+# Appends OCI source-provenance labels derived from the git repo at <repo-dir>.
+# A no-op outside a git work tree.
+#
+# Args: <cmd-array-name> <repo-dir>
+docker_build_add_oci_labels() {
+    if (( $# != 2 )) || [[ -z "$1" || -z "$2" ]]; then
+        echo >&2 "ERROR: docker_build_add_oci_labels requires a command array and a repo directory"
+        return 2
+    fi
+    local cmd_name="$1" repo_dir="$2"
+
+    command -v git &>/dev/null || return 0
+    git -C "${repo_dir}" rev-parse --is-inside-work-tree &>/dev/null || return 0
+
+    local revision
+    if revision="$(git -C "${repo_dir}" rev-parse HEAD 2>/dev/null)"; then
+        docker_utils_append_args "${cmd_name}" \
+            "--label" "org.opencontainers.image.revision=${revision}"
+    fi
+
+    local remote_url
+    if remote_url="$(git -C "${repo_dir}" remote get-url origin 2>/dev/null)"; then
+        # Credentials stripped: a label travels with the image to every registry
+        # and `docker inspect` that ever sees it.
+        remote_url="$(_docker_build_replace_userinfo "${remote_url}")"
+        docker_utils_append_args "${cmd_name}" \
+            "--label" "org.opencontainers.image.source=${remote_url}"
+    fi
+    return 0
+}
+
+# Echoes and runs the assembled command.
+#
+# Args: <cmd-array-name>
+docker_build_run() {
+    if (( $# != 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: docker_build_run requires a command array"
+        return 2
+    fi
+    local length
+    length="$(docker_utils_array_length "$1")" || return 2
+    if (( length == 0 )); then
+        echo >&2 "ERROR: docker_build_run got an empty command array: $1"
+        return 2
+    fi
+
+    if ! docker buildx version &>/dev/null; then
+        echo >&2 "ERROR: docker buildx is required (Docker 23 or newer)."
+        return 1
+    fi
+
+    # Copied out by name, since the array belongs to the caller.
+    local cmd
+    eval "cmd=(\"\${$1[@]}\")"
+
+    # The echoed line is for humans and CI logs, so proxy credentials are masked
+    # there. The command itself runs with the values untouched.
+    local arg printable=()
+    for arg in "${cmd[@]}"; do
+        printable+=("$(_docker_build_replace_userinfo "${arg}" "***@")")
+    done
+    echo "Running: ${printable[*]}"
+
+    "${cmd[@]}"
+}
+
+# The common composition: proxy args, forwarded build args, pull, labels, run.
+# CA trust is deliberately not included -- it's opt-in and the consumer calls
+# ca_trust_add_build_args itself.
+#
+# Args: <cmd-array-name> <repo-dir> [build-arg-var-name...]
+docker_build_finalize() {
+    if (( $# < 2 )) || [[ -z "$1" || -z "$2" ]]; then
+        echo >&2 "ERROR: docker_build_finalize requires a command array and a repo directory"
+        return 2
+    fi
+    local cmd_name="$1" repo_dir="$2"
+    shift 2
+
+    docker_build_add_proxy_args "${cmd_name}" || return
+    docker_build_add_env_build_args "${cmd_name}" "$@" || return
+    docker_build_add_pull_arg "${cmd_name}" || return
+    docker_build_add_oci_labels "${cmd_name}" "${repo_dir}" || return
+    docker_build_run "${cmd_name}"
+}

--- a/exports/docker/ca-trust/README.md
+++ b/exports/docker/ca-trust/README.md
@@ -1,75 +1,145 @@
 # CA trust
 
-A library for propagating the host's trusted CA certificates into containerized builds that run behind a TLS-inspecting (e.g., corporate) gateway. Trust is wired up through environment variables and a bind-mounted staging directory, so certificates are never installed into an image or persisted in layers, caches, or artifacts.
+A library for propagating the host's trusted CA certificates into containerized builds that run behind a TLS-inspecting (e.g., corporate) gateway. Trust is wired up through environment variables and an ephemeral mount, so certificates are never installed into an image or persisted in layers, caches, or artifacts.
 
-The examples below assume the consuming project has this repo as a submodule at `tools/yscope-dev-utils` (see the [usage docs](../../../docs/index.md#usage)) and mounts itself at `/repo` inside the build container; adjust the paths to your layout.
+The examples below assume the consuming project has this repo as a submodule at `tools/yscope-dev-utils` (see the [usage docs](../../../docs/index.md#usage)); adjust the paths to your layout.
+
+## Onboarding a project
+
+1. Add this repo as a submodule — see the [usage docs](../../../docs/index.md#usage).
+2. Decide which halves you need. Certificates during **image builds** ([below](#docker-build)), inside **running containers** ([below](#docker-run)), or both. They're independent.
+3. Make it opt-in. Put it behind a flag (`--with-ca-certs` in `y-scope/clp` and `y-scope/clp-plugin-presto-connector`) so the default path — and CI — does nothing at all. CI has no TLS-inspecting gateway and should not be staging certificates.
+4. If your build installs packages with `apt` or `dnf`, wire up their own options as well. They ignore the environment variables this library sets; see [Package managers](#package-managers-need-to-be-told-separately).
+5. Verify with a control. Build **without** a bundle first and confirm it fails the way you expect, then build with one and confirm it passes. A passing build proves nothing on its own — it may simply not have needed the certificates. `mitmproxy` makes a usable stand-in for a corporate gateway if you don't have one.
 
 ## Requirements
 
-* Host: `bash`, plus a container runtime that supports bind mounts (the examples use Docker).
+* Host: `bash` 3.2 or newer (macOS's `/bin/bash` qualifies), plus a container runtime that supports bind mounts.
+  * `docker build` support additionally needs BuildKit with named build contexts: Docker 23 or newer.
   * `openssl` (optional): used to drop expired certificates during staging; without it, the bundle is copied as-is.
 * Container: `bash`.
   * `findmnt` (optional): used to verify `CA_TRUST_DIR` is not on the container's writable overlay; without it, a warning is printed and the build proceeds.
   * A JDK providing `keytool` (JVM builds only): used to generate the PKCS#12 trust store; without it, JVM trust setup is skipped.
 
-## Quick start
+## Docker build
 
-On the host, stage the CA bundle into a temporary directory. Bind-mount that directory (writable) into the container, point `CA_TRUST_DIR` at the mount, and source `container.sh` before running the build:
+Declare an empty default stage so the mount resolves when no CA trust is supplied, and guard the `RUN` so it works either way:
 
-```bash
-# Host side
-source tools/yscope-dev-utils/exports/docker/ca-trust/host.sh
+```dockerfile
+# syntax=docker/dockerfile:1
+FROM scratch AS ca_trust
 
-CA_TRUST_HOST_DIR="$(mktemp -d)"
-trap 'rm -rf "${CA_TRUST_HOST_DIR}"' EXIT
-
-# Creates ${CA_TRUST_HOST_DIR}/ca-bundle.pem (read-only). Check the status: running
-# the build without host CA trust is the failure this library exists to avoid.
-stage_host_ca_bundle "${CA_TRUST_HOST_DIR}" || exit 1
-
-docker run --rm \
-    --mount "type=bind,src=${PWD},dst=/repo" \
-    --mount "type=bind,src=${CA_TRUST_HOST_DIR},dst=${CA_TRUST_CONTAINER_DIR}" \
-    --env "CA_TRUST_DIR=${CA_TRUST_CONTAINER_DIR}" \
-    --env "CA_TRUST_JVM=1" \
-    --env MAVEN_OPTS \
-    <image> \
-    bash -c '
-        source /repo/tools/yscope-dev-utils/exports/docker/ca-trust/container.sh
-        # Run the build; curl, git, pip, and Maven now trust the host CAs.
-    '
+FROM <base-image>
+RUN --mount=type=bind,from=ca_trust,target=/run/ca-trust \
+    if [ -e /run/ca-trust/container.sh ]; then \
+        export CA_TRUST_DIR=/run/ca-trust; \
+        runner="bash /run/ca-trust/container-exec.sh"; \
+    else runner=""; fi; \
+    $runner <your build command>
 ```
 
-`CA_TRUST_JVM=1` and `--env MAVEN_OPTS` are only needed for JVM builds; see [JVM builds](#jvm-builds).
+On the host, stage the bundle and the library into one directory and pass it as the `ca_trust` build context:
+
+```bash
+source tools/yscope-dev-utils/exports/docker/ca-trust/host.sh
+
+ca_trust_dir="$(mktemp -d)"
+trap 'rm -rf "${ca_trust_dir}"' EXIT
+
+# Check the status: building without the CA trust you asked for is the failure
+# this library exists to prevent.
+ca_trust_stage_or_fail "${ca_trust_dir}" || exit 1
+ca_trust_stage_build_context "${ca_trust_dir}" || exit 1
+
+build_cmd=(docker buildx build --tag <tag> --file <dockerfile> <context>)
+ca_trust_add_build_args build_cmd "${ca_trust_dir}"
+"${build_cmd[@]}"
+```
+
+Omit those calls and the `FROM scratch AS ca_trust` stage supplies an empty directory: the `RUN` falls through to the plain command and the image keeps its own distro trust store. That is what makes CA trust opt-in, and why CI needs no CA configuration at all.
+
+A named build context is used rather than a BuildKit secret because secrets are capped at 500KiB and corporate CA bundles can exceed that. Bind mounts of a build context are equally ephemeral: nothing lands in a layer or in `docker history`.
+
+## Docker run
+
+Bind-mount the staging directory (writable) into the container, point `CA_TRUST_DIR` at the mount, and source `container.sh` before running the build:
+
+```bash
+source tools/yscope-dev-utils/exports/docker/ca-trust/host.sh
+
+ca_trust_dir="$(mktemp -d)"
+trap 'rm -rf "${ca_trust_dir}"' EXIT
+ca_trust_stage_or_fail "${ca_trust_dir}" || exit 1
+
+run_cmd=(docker run --rm --mount "type=bind,src=${PWD},dst=/repo")
+CA_TRUST_JVM=1 ca_trust_add_run_args run_cmd "${ca_trust_dir}"
+"${run_cmd[@]}" <image> bash -c '
+    source /repo/tools/yscope-dev-utils/exports/docker/ca-trust/container.sh
+    # Run the build; curl, git, pip, and Maven now trust the host CAs.
+'
+```
+
+`CA_TRUST_JVM=1` is only needed for JVM builds; see [JVM builds](#jvm-builds).
 
 ## Host API (`host.sh`)
 
-`stage_host_ca_bundle <trust-dir>` writes the host's CA bundle to `<trust-dir>/${CA_TRUST_BUNDLE_FILENAME}` (read-only, `0444`):
+`ca_trust_stage_host_bundle <trust-dir>` writes the host's CA bundle to `<trust-dir>/${CA_TRUST_BUNDLE_FILENAME}` (read-only, `0444`):
 
 * The bundle is taken from `SSL_CERT_FILE` when set; otherwise, common Linux CA-bundle locations are searched. If none is found (e.g., on macOS without `SSL_CERT_FILE`), an empty file is created and the build proceeds without host CA context.
 * Expired certificates are dropped during staging (when `openssl` is available on the host), since a single expired certificate in a bundle can break TLS verification for otherwise-valid chains.
+* `CA_TRUST_BUNDLE_SEARCH_PATHS` (colon-separated) overrides the default search list; it exists so the "no host bundle" path is reachable in tests.
+
+`ca_trust_stage_or_fail <trust-dir>` stages the bundle and fails if nothing usable was found. `ca_trust_stage_host_bundle` tolerates an empty bundle on purpose, because a build with no host CA context is normal; a caller that explicitly asked for CA trust wants the opposite, so use this instead of repeating the check.
+
+`ca_trust_stage_build_context <trust-dir>` copies this library into the staging directory, so one named build context carries both the bundle and the scripts that consume it.
+
+`ca_trust_add_build_args <cmd-array-name> <trust-dir>` and `ca_trust_add_run_args <cmd-array-name> <trust-dir>` append the corresponding Docker flags to a caller-owned bash array.
 
 Constants:
 
 * `CA_TRUST_BUNDLE_FILENAME` (`ca-bundle.pem`): the staged bundle's filename; `container.sh` reads it from `CA_TRUST_DIR` by this name.
-* `CA_TRUST_CONTAINER_DIR` (`/run/ca-trust`): the conventional in-container mount point for the staged trust directory, passed to the container as `CA_TRUST_DIR`.
+* `CA_TRUST_CONTAINER_DIR` (`/run/ca-trust`): the conventional in-container mount point.
+* `CA_TRUST_BUILD_CONTEXT_NAME` (`ca_trust`): the named build context. A Dockerfile can't read these shell constants, so this name is also spelled out in each consuming Dockerfile; keep the two in sync.
 
-The caller owns the staging directory and cleans it up (e.g., with `trap`, as above). The scripts never modify the host's or the container's installed trust stores.
+The caller owns the staging directory and cleans it up. The scripts never modify the host's or the container's installed trust stores.
 
 ## Container API (`container.sh`)
 
-Source it after setting `CA_TRUST_DIR` to the (writable) mount of the staged trust directory. It's a no-op when `CA_TRUST_DIR` is unset, so builds that don't mount a trust directory are unaffected.
+Source it after setting `CA_TRUST_DIR` to the mount of the staged trust directory. It's a no-op when `CA_TRUST_DIR` is unset, so builds that don't mount a trust directory are unaffected.
 
-When the staged bundle is non-empty, it exports `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `PIP_CERT`, `REQUESTS_CA_BUNDLE`, and `SSL_CERT_FILE`, covering most TLS clients used in builds.
+When the staged bundle is non-empty, it exports `CURL_CA_BUNDLE`, `GIT_SSL_CAINFO`, `PIP_CERT`, `REQUESTS_CA_BUNDLE`, and `SSL_CERT_FILE`. An empty bundle deliberately exports nothing: pointing `SSL_CERT_FILE` at an empty file would break all TLS rather than falling back to the system store.
+
+### Package managers need to be told separately
+
+`curl`, `git`, `pip`, and `apk` read the variables above. **`apt` and `dnf` read none of them** -- verified: `apt` over https still fails certificate verification with `SSL_CERT_FILE` and `CURL_CA_BUNDLE` both pointing at a valid bundle, and `dnf` succeeds with both set to `/dev/null`. If your build installs packages with either, pass the bundle explicitly:
+
+```bash
+apt-get -o "Acquire::https::CaInfo=${CA_TRUST_DIR}/ca-bundle.pem" update
+dnf --setopt="sslcacert=${CA_TRUST_DIR}/ca-bundle.pem" install ...
+```
+
+Guard both on the bundle existing, so the default (no CA trust supplied) is unaffected. See `components/core/tools/scripts/lib_install/ca-trust-pkg-opts.sh` in `y-scope/clp` for one way to factor this out.
+
+Anything reading none of these -- `wget`, Node (`NODE_EXTRA_CA_CERTS`), rustls-based tooling -- also needs its own configuration.
+
+`container-exec.sh <cmd> [args...]` sources `container.sh` and then execs the command. Dockerfile `RUN` steps are executed by `/bin/sh` while `container.sh` needs `bash`, so this wrapper keeps the Dockerfile free of nested quoting.
 
 ### JVM builds
 
-JVM tools (Maven, Gradle, ...) don't read the environment variables above, so JVM support is opt-in via `CA_TRUST_JVM=1`. When it's set, the bundle is non-empty, and `keytool` is available, `container.sh` uses the container's own JDK to generate a PKCS#12 trust store from the bundle at `${CA_TRUST_DIR}/truststore.p12`, then appends the corresponding `-Djavax.net.ssl.trustStore*` options to `MAVEN_OPTS`, preserving any caller-supplied value (forward `MAVEN_OPTS` into the container, as in the quick start). A generation failure is an error. See [generators/java-pkcs12](generators/java-pkcs12/README.md) for details.
+JVM tools (Maven, Gradle, ...) don't read the environment variables above, so JVM support is opt-in via `CA_TRUST_JVM=1`. When it's set, the bundle is non-empty, and `keytool` is available, `container.sh` uses the container's own JDK to generate a PKCS#12 trust store from the bundle at `${CA_TRUST_DIR}/truststore.p12`, then appends the corresponding `-Djavax.net.ssl.trustStore*` options to `MAVEN_OPTS`, preserving any caller-supplied value. A generation failure is an error. See [generators/java-pkcs12](generators/java-pkcs12/README.md) for details.
+
+Options are *appended*, space-separated. Callers that string-parse `MAVEN_OPTS` for a flag they add after sourcing `container.sh` rely on that ordering.
+
+This is a `docker run` feature. A `docker build` gets the trust directory through a bind mount of the named build context, and those are read-only, so generating the trust store there fails. A build that needs JVM trust must add `rw` to its `RUN --mount`, which makes the writes land in a scratch layer that BuildKit discards. Nothing in this repo's consumers does that today.
 
 ## Persistence contract
 
-`CA_TRUST_DIR` must be a writable host bind-mount or tmpfs, not the container's writable overlay: a file on the overlay would be retained by `docker commit`, while a bind mount is not part of any committed image. `container.sh` verifies this with `findmnt` and refuses to write to the overlay; if `findmnt` is unavailable, it warns and proceeds. All staged and generated files live in the caller's staging directory and disappear when the caller cleans it up.
+`CA_TRUST_DIR` must be a bind-mount or tmpfs, not the container's writable overlay: a file on the overlay would be retained by `docker commit`, while a mount is not part of any committed image. `container.sh` verifies this with `findmnt` before writing the JVM trust store and refuses to write to the overlay; if `findmnt` is unavailable, it warns and proceeds. All staged and generated files live in the caller's staging directory and disappear when the caller cleans it up.
 
 ## Extensibility
 
 Add a backend under `generators/` when a trust format can't consume the PEM bundle directly. Keep host discovery and lifecycle in `host.sh`; keep format-specific conversion in the backend, run in-container. See [generators/java-pkcs12](generators/java-pkcs12/README.md) as a template.
+
+## Why there's no taskfile wrapper
+
+Unlike most `exports/` libraries, this one isn't consumed through Task. Its functions must be `source`d into the caller's shell to mutate a command array and export variables, and Task runs each `cmd` in a fresh process.

--- a/exports/docker/ca-trust/container-exec.sh
+++ b/exports/docker/ca-trust/container-exec.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# Sources container.sh, then execs the given command with the CA trust
+# environment in place.
+#
+# Exists for `docker build`: a Dockerfile RUN is executed by /bin/sh, while
+# container.sh needs bash (BASH_SOURCE, [[ ]]). Without this wrapper every RUN
+# would have to spell out `bash -c '. .../container.sh && <cmd>'`, which is
+# unwritable when <cmd> itself contains single-quoted arguments (sed scripts,
+# for instance). It's also usable as a `docker run --entrypoint`.
+#
+# Usage: container-exec.sh <cmd> [args...]
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+if (( $# == 0 )); then
+    echo >&2 "ERROR: container-exec.sh requires a command to run"
+    exit 2
+fi
+
+_ca_trust_exec_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
+
+# container.sh signals failure with `return 1` when sourced, which `errexit`
+# doesn't catch across a source; check explicitly.
+# shellcheck source=exports/docker/ca-trust/container.sh
+if ! source "${_ca_trust_exec_dir}/container.sh"; then
+    echo >&2 "ERROR: failed to configure CA trust"
+    exit 1
+fi
+
+unset _ca_trust_exec_dir
+
+exec "$@"

--- a/exports/docker/ca-trust/container.sh
+++ b/exports/docker/ca-trust/container.sh
@@ -14,14 +14,19 @@
 # by `docker commit`; a bind mount is not part of any committed image. This
 # script refuses to write to the overlay.
 
+# SC2317: this file is designed to work both when sourced and when executed, so
+# `return N 2>/dev/null || exit N` is deliberate; shellcheck can only see the
+# sourced half and reports the `exit` as unreachable.
+# shellcheck disable=SC2317
+
 if [[ -z "${CA_TRUST_DIR:-}" ]]; then
     return 0 2>/dev/null || exit 0
 fi
 
 _ca_trust_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 # Spelled out rather than read from host.sh's CA_TRUST_BUNDLE_FILENAME: host.sh
-# is the host's half of the library and isn't guaranteed to be beside this file
-# in the container. Renaming the bundle means changing both.
+# is the one file ca_trust_stage_build_context leaves behind, so it isn't here to
+# source. Renaming the bundle means changing both.
 #
 # Internal to this file, like the other bare names here; the caller gets the
 # environment variables exported below, and all of these are unset at the end.
@@ -81,6 +86,11 @@ if [[ -n "${CA_TRUST_JVM:-}" ]] && [[ -s "${HOST_CA_BUNDLE:-}" ]] && command -v 
     fi
 
     # Preserve any Maven options supplied by the caller.
+    #
+    # Append (never prepend) space-separated -D flags. Callers may string-parse
+    # MAVEN_OPTS for a flag they add after sourcing this file -- taking
+    # everything after the last occurrence -- so anything appended here must
+    # stay ahead of the caller's own additions.
     _host_ca_maven_opts="${MAVEN_OPTS:-}"
     [[ -n "${_host_ca_maven_opts}" ]] && _host_ca_maven_opts="${_host_ca_maven_opts} "
     _host_ca_maven_opts="${_host_ca_maven_opts}-Djavax.net.ssl.trustStore=${HOST_CA_JAVA_TRUST_STORE}"

--- a/exports/docker/ca-trust/host.sh
+++ b/exports/docker/ca-trust/host.sh
@@ -7,6 +7,9 @@ if [[ "${_CA_TRUST_HOST_SH_LOADED:-}" == "1" ]]; then
 fi
 readonly _CA_TRUST_HOST_SH_LOADED=1
 
+# shellcheck source=exports/docker/utils.sh
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")/.." &>/dev/null && pwd)/utils.sh"
+
 # Conventional staged filename for the host CA bundle. container.sh reads it
 # from CA_TRUST_DIR by this name (HOST_CA_BUNDLE) and generates the Java
 # PKCS#12 trust store in-container from it.
@@ -18,6 +21,18 @@ readonly CA_TRUST_BUNDLE_FILENAME="ca-bundle.pem"
 # PKCS#12 trust store back into it. Kept in host.sh so the path is defined
 # once on the host side rather than hardcoded by each caller.
 readonly CA_TRUST_CONTAINER_DIR="/run/ca-trust"
+
+# Name of the Docker named build context used to carry the staging directory
+# into `docker build`. A Dockerfile can't read these shell constants, so the
+# name is also spelled out in each consuming Dockerfile's
+# `--mount=type=bind,from=...`; keep the two in sync.
+#
+# Consumers must declare `FROM scratch AS ca_trust` so the mount resolves to an
+# empty directory when no context is passed. That is what makes CA trust opt-in:
+# an unprovided named context is fatal (BuildKit tries to pull it as an image),
+# while an empty default lets untrusted-network-free builds and CI run with no
+# CA configuration at all.
+readonly CA_TRUST_BUILD_CONTEXT_NAME="ca_trust"
 
 # Copies <src> to <dest>, dropping any certificate whose validity period has
 # already ended. A stale corporate CA bundle otherwise gets propagated
@@ -62,14 +77,14 @@ _stage_ca_bundle_without_expired_certs() {
 # returns nonzero only on an error.
 #
 # Args: <trust-dir>
-stage_host_ca_bundle() {
+ca_trust_stage_host_bundle() {
     if (( $# != 1 )) || [[ -z "$1" ]]; then
-        echo >&2 "ERROR: stage_host_ca_bundle requires a trust directory"
+        echo >&2 "ERROR: ca_trust_stage_host_bundle requires a trust directory"
         return 2
     fi
     local trust_dir="$1"
     if [[ -L "${trust_dir}" || ( -e "${trust_dir}" && ! -d "${trust_dir}" ) ]]; then
-        echo >&2 "ERROR: stage_host_ca_bundle target is not a directory: ${trust_dir}"
+        echo >&2 "ERROR: ca_trust_stage_host_bundle target is not a directory: ${trust_dir}"
         return 1
     fi
     if ! mkdir -p "${trust_dir}"; then
@@ -94,6 +109,11 @@ stage_host_ca_bundle() {
             return 1
         fi
         candidates=("${SSL_CERT_FILE}")
+    elif [[ -n "${CA_TRUST_BUNDLE_SEARCH_PATHS:-}" ]]; then
+        # Colon-separated override for the default search list. Exists so the
+        # "no host bundle found" branch below is reachable in tests: every Linux
+        # CI runner has a bundle at one of the default locations.
+        IFS=':' read -r -a candidates <<< "${CA_TRUST_BUNDLE_SEARCH_PATHS}"
     else
         candidates=(
             /etc/ssl/certs/ca-certificates.crt
@@ -144,5 +164,107 @@ stage_host_ca_bundle() {
         rm -f "${staged_bundle}"
         echo >&2 "ERROR: failed to replace host CA bundle: ${dest}"
         return 1
+    fi
+}
+
+# Stages the host CA bundle and fails if it produced nothing usable.
+#
+# `ca_trust_stage_host_bundle` deliberately tolerates an empty bundle: a build
+# with no host CA context is normal. A caller that explicitly asked for CA trust
+# is in the opposite position -- finding nothing is an error, not a default -- so
+# every such caller pairs the staging call with the same check. This is that
+# pair, so the check can't drift between them.
+#
+# Args: <trust-dir>
+ca_trust_stage_or_fail() {
+    if (( $# != 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: ca_trust_stage_or_fail requires a trust directory"
+        return 2
+    fi
+    local trust_dir="$1"
+
+    ca_trust_stage_host_bundle "${trust_dir}" || return 1
+
+    local staged="${trust_dir}/${CA_TRUST_BUNDLE_FILENAME}"
+    if [[ ! -f "${staged}" || ! -r "${staged}" || ! -s "${staged}" ]]; then
+        echo >&2 "ERROR: no usable host CA bundle was found."
+        echo >&2 "  Set SSL_CERT_FILE to your CA bundle, or don't ask for CA trust."
+        return 1
+    fi
+}
+
+# Copies this library into <trust-dir> so a single named build context carries
+# both the staged bundle and the scripts that consume it. `docker build` has no
+# bind mounts, and a Dockerfile can only COPY from its own build context — which
+# for most consumers doesn't include this submodule.
+#
+# The whole directory is copied, including generators/, so container.sh's JVM
+# branch keeps working for build-time consumers that opt into it.
+#
+# Args: <trust-dir>
+ca_trust_stage_build_context() {
+    if (( $# != 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: ca_trust_stage_build_context requires a trust directory"
+        return 2
+    fi
+    local trust_dir="$1"
+    if [[ ! -d "${trust_dir}" ]]; then
+        echo >&2 "ERROR: trust directory doesn't exist: ${trust_dir}"
+        return 1
+    fi
+
+    local lib_dir
+    lib_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)" || return 1
+
+    local entry
+    for entry in "${lib_dir}"/*; do
+        # Skip host.sh: it's the caller's half and has no use in the container.
+        [[ "$(basename "${entry}")" == "host.sh" ]] && continue
+        if ! cp -R "${entry}" "${trust_dir}/"; then
+            echo >&2 "ERROR: failed to stage ca-trust library into: ${trust_dir}"
+            return 1
+        fi
+    done
+}
+
+# Appends the `docker build` flags that expose <trust-dir> to the build.
+#
+# A named build context is used rather than a BuildKit secret because secrets
+# are capped at 500KiB and corporate CA bundles can exceed that. Bind mounts of
+# a build context are equally ephemeral: nothing lands in a layer or in
+# `docker history`.
+#
+# Args: <cmd-array-name> <trust-dir>
+ca_trust_add_build_args() {
+    if (( $# != 2 )) || [[ -z "$1" || -z "$2" ]]; then
+        echo >&2 "ERROR: ca_trust_add_build_args requires a command array and a trust directory"
+        return 2
+    fi
+    docker_utils_append_args "$1" "--build-context" "${CA_TRUST_BUILD_CONTEXT_NAME}=$2"
+}
+
+# Appends the `docker run` flags that mount <trust-dir> into the container and
+# point container.sh at it. Set CA_TRUST_JVM=1 in the environment beforehand to
+# also forward the JVM trust-store opt-in and MAVEN_OPTS.
+#
+# Args: <cmd-array-name> <trust-dir>
+ca_trust_add_run_args() {
+    if (( $# != 2 )) || [[ -z "$1" || -z "$2" ]]; then
+        echo >&2 "ERROR: ca_trust_add_run_args requires a command array and a trust directory"
+        return 2
+    fi
+    docker_utils_append_args "$1" \
+        "--mount" "type=bind,src=$2,dst=${CA_TRUST_CONTAINER_DIR}" \
+        "--env" "CA_TRUST_DIR=${CA_TRUST_CONTAINER_DIR}"
+    if [[ -n "${CA_TRUST_JVM:-}" ]]; then
+        # Pass CA_TRUST_JVM by value: the pass-through `--env NAME` form is
+        # resolved by the docker client when the command finally runs, and a
+        # caller that set the variable only for this call -- `CA_TRUST_JVM=1
+        # ca_trust_add_run_args ...` -- no longer has it set by then, silently
+        # dropping JVM trust. MAVEN_OPTS stays pass-through on purpose: the
+        # point is to forward whatever the host has at run time.
+        docker_utils_append_args "$1" \
+            "--env" "CA_TRUST_JVM=${CA_TRUST_JVM}" \
+            "--env" "MAVEN_OPTS"
     fi
 }

--- a/exports/docker/utils.sh
+++ b/exports/docker/utils.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# Small shell helpers shared by the docker libraries in this directory.
+
+if [[ "${_DOCKER_UTILS_SH_LOADED:-}" == "1" ]]; then
+    return 0
+fi
+readonly _DOCKER_UTILS_SH_LOADED=1
+
+# Appends values to the caller's array, which is passed by name.
+#
+# The obvious implementation is a bash nameref (`local -n`), but that needs bash
+# 4.3 and macOS still ships bash 3.2 as /bin/bash -- and a macOS laptop behind a
+# corporate TLS gateway is exactly who reaches for these libraries. So the
+# append goes through `eval` instead, with every value rendered by `printf %q`.
+# That is what %q is for: it emits a token the shell parses back to the original
+# byte-for-byte, so values containing spaces, quotes, `$`, or newlines -- proxy
+# and mirror URLs routinely have them -- arrive intact.
+#
+# Args: <array-name> [value...]
+docker_utils_append_args() {
+    if (( $# < 1 )) || [[ -z "$1" ]]; then
+        echo >&2 "ERROR: docker_utils_append_args requires an array name"
+        return 2
+    fi
+    # Only ever an identifier chosen by the calling library, never user data,
+    # but validate anyway since the name is what gets evaluated.
+    if [[ ! "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo >&2 "ERROR: not a valid array name: $1"
+        return 2
+    fi
+
+    local array_name="$1"
+    shift
+    if (( $# == 0 )); then
+        return 0
+    fi
+
+    eval "${array_name}+=($(printf '%q ' "$@"))"
+}
+
+# Echoes the number of elements in the array named by <array-name>.
+#
+# Args: <array-name>
+docker_utils_array_length() {
+    if (( $# != 1 )) || [[ ! "$1" =~ ^[A-Za-z_][A-Za-z0-9_]*$ ]]; then
+        echo >&2 "ERROR: docker_utils_array_length requires an array name"
+        return 2
+    fi
+    eval "echo \"\${#$1[@]}\""
+}


### PR DESCRIPTION
# Description

## Why

Corporate networks often run a TLS-inspecting gateway that re-signs HTTPS traffic with the company's own certificate authority. Your laptop trusts it; a container doesn't. Builds then fail with certificate errors that give no hint of the cause, so each project invents its own fix — `y-scope/clp` and `y-scope/clp-plugin-presto-connector` both had one, and they agreed on almost nothing.

**Stacked on #120**, which vendors the connector's library as-is. That library only covered containers that are already running; the connector handled the image-build case separately, in its own build scripts. This PR brings that second half into the library too, so one implementation serves both projects — and nothing from the host's trust store is ever written into an image.

## What changed

**1. Certificates during image builds** (~140 lines in `ca-trust`).

Until now the library could only hand certificates to a container that was already running. `y-scope/clp` needs them earlier — while an image is being built, because that's when it downloads packages.

The mechanism isn't new. `y-scope/clp-plugin-presto-connector` already does exactly this for its dependency image: the certificates are passed in as a folder that Docker attaches for the duration of a single build step and then discards, so they never become part of the finished image. It got there the hard way — Docker's purpose-built feature for passing files into a build (`--secret`) rejects anything over 500KiB, and a customer's certificate bundle exceeded that. What's new here is lifting that proven approach out of the connector's own build scripts and into the shared library, so it isn't reimplemented per project.

A project opts in by adding one line to its Dockerfile that supplies an empty folder by default. Builds that pass nothing — which is all of CI — behave exactly as before. New functions: `ca_trust_stage_build_context`, `ca_trust_add_build_args`, `ca_trust_add_run_args`, plus `container-exec.sh`, a small wrapper that exists because Docker runs build steps with a shell that can't read the library directly.

**2. A separate `docker/build` library** (~210 lines).

Nothing to do with certificates: it assembles the repetitive parts of a `docker build` command — forwarding proxy settings, passing through build options, refreshing the base image, and stamping the image with which commit produced it. It's here because the `y-scope/clp` script this replaces did all of that in the same file, so it has to land somewhere.

It keeps the command as a list of separate words rather than one long string, so a value containing a space, quote, or `$` is never re-split by the shell — proxy and mirror URLs routinely contain all three. It runs on bash 3.2, which is what macOS ships, since a corporate laptop is a likely place to need this.

It also strips credentials from URLs before they leave the build: a git remote like `https://user:token@github.com/org/repo` would otherwise be written into the image's source label, and a proxy password would be printed into the build log. The command still runs with the real values.

**Breaking:** `stage_host_ca_bundle` is renamed to `ca_trust_stage_host_bundle`, for consistency with the new function names. The library is unreleased and its only consumer is updated in lockstep in y-scope/clp-plugin-presto-connector#47.

The README shows deletions because this PR rewrites the version #120 adds, to document the build-time half. Against `main` the two PRs are purely additive.

# Checklist

* [x] The PR satisfies the [contribution guidelines][yscope-contrib-guidelines].
* [x] This is a breaking change and that has been indicated in the PR title, OR this isn't a breaking change.
* [x] Necessary docs have been updated, OR no docs need to be updated.

# Validation performed

Tests for both libraries are stacked on top in #122, including regressions for the two bugs fixed here: `CA_TRUST_JVM` being passed by reference, and `docker_build_add_env_build_args` leaking a nonzero status to an `errexit` caller when its last variable was unset.

On real builds: a 28MB bundle transfers intact through a named build context and leaves no trace in any layer or in `docker history`, while Docker's `--secret` rejects the same file with `secret too big. max size 500KiB`.

Exercised end to end by the two consumer PRs — y-scope/clp-plugin-presto-connector#47 and y-scope/clp#2451 — including a build through a real TLS-inspecting proxy, which reports 24 certificate errors without the staged bundle and 0 with it.

[yscope-contrib-guidelines]: https://docs.yscope.com/dev-guide/contrib-guides-overview.html


